### PR TITLE
Tokenize apex triggers

### DIFF
--- a/grammars/apex.tmLanguage
+++ b/grammars/apex.tmLanguage
@@ -119,7 +119,7 @@
           </dict>
         </array>
       </dict>
-      <key>class-or-struct-members</key>
+      <key>class-or-trigger-members</key>
       <dict>
         <key>patterns</key>
         <array>
@@ -280,6 +280,10 @@
           <dict>
             <key>include</key>
             <string>#this-expression</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#trigger-context-declaration</string>
           </dict>
           <dict>
             <key>include</key>
@@ -473,7 +477,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#class-or-struct-members</string>
+                <string>#class-or-trigger-members</string>
               </dict>
             </array>
           </dict>
@@ -554,6 +558,14 @@
                   </dict>
                   <dict>
                     <key>include</key>
+                    <string>#trigger-operator-statement</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>#punctuation-comma</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
                     <string>#expression</string>
                   </dict>
                 </array>
@@ -593,7 +605,11 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#class-or-struct-members</string>
+                <string>#statement</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#class-or-trigger-members</string>
               </dict>
             </array>
           </dict>
@@ -620,6 +636,104 @@
             <string>keyword.control.trigger.after.apex</string>
           </dict>
         </dict>
+      </dict>
+      <key>trigger-operator-statement</key>
+      <dict>
+        <key>name</key>
+        <string>keyword.operator.trigger.apex</string>
+        <key>match</key>
+        <string>\b(insert|update|delete|merge|upsert|undelete)\b</string>
+      </dict>
+      <key>trigger-context-declaration</key>
+      <dict>
+        <key>begin</key>
+        <string>\b(?:(Trigger))\b(\.)\b</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>support.class.trigger.apex</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.accessor.apex</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(?=\})|(?=;)|(?=\)|(?=\]))</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>support.type.trigger.apex</string>
+            <key>match</key>
+            <string>\b(isExecuting|isInsert|isUpdate|isDelete|isBefore|isAfter|isUndelete|new|newMap|old|oldMap|size)\b</string>
+          </dict>
+          <dict>
+            <key>match</key>
+            <string>(?:(\.))([[:alpha:]]+)(?=\()</string>
+            <key>captures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.accessor.apex</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>support.function.trigger.apex</string>
+              </dict>
+            </dict>
+          </dict>
+          <dict>
+            <key>begin</key>
+            <string>\(</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.parenthesis.open.apex</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>\)</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.parenthesis.close.apex</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#trigger-type-statement</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#comment</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#punctuation-comma</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#expression</string>
+              </dict>
+            </array>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#expression</string>
+          </dict>
+        </array>
       </dict>
       <key>enum-declaration</key>
       <dict>
@@ -900,7 +1014,15 @@
         <array>
           <dict>
             <key>include</key>
+            <string>#trigger-context-declaration</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#from-clause</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#in-clause</string>
           </dict>
           <dict>
             <key>include</key>
@@ -935,6 +1057,19 @@
           <dict>
             <key>name</key>
             <string>storage.type.apex</string>
+          </dict>
+        </dict>
+      </dict>
+      <key>in-clause</key>
+      <dict>
+        <key>match</key>
+        <string>(IN)\b\s*</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.operator.query.in.apex</string>
           </dict>
         </dict>
       </dict>
@@ -1119,7 +1254,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#class-or-struct-members</string>
+            <string>#class-or-trigger-members</string>
           </dict>
         </array>
       </dict>
@@ -1202,7 +1337,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#class-or-struct-members</string>
+            <string>#class-or-trigger-members</string>
           </dict>
         </array>
       </dict>

--- a/grammars/apex.tmLanguage.cson
+++ b/grammars/apex.tmLanguage.cson
@@ -78,7 +78,7 @@ repository:
         include: "#punctuation-semicolon"
       }
     ]
-  "class-or-struct-members":
+  "class-or-trigger-members":
     patterns: [
       {
         include: "#comment"
@@ -195,6 +195,9 @@ repository:
         include: "#this-expression"
       }
       {
+        include: "#trigger-context-declaration"
+      }
+      {
         include: "#conditional-operator"
       }
       {
@@ -308,7 +311,7 @@ repository:
             name: "punctuation.curlybrace.close.apex"
         patterns: [
           {
-            include: "#class-or-struct-members"
+            include: "#class-or-trigger-members"
           }
         ]
       }
@@ -353,6 +356,12 @@ repository:
                 include: "#trigger-type-statement"
               }
               {
+                include: "#trigger-operator-statement"
+              }
+              {
+                include: "#punctuation-comma"
+              }
+              {
                 include: "#expression"
               }
             ]
@@ -376,7 +385,10 @@ repository:
             name: "punctuation.curlybrace.close.apex"
         patterns: [
           {
-            include: "#class-or-struct-members"
+            include: "#statement"
+          }
+          {
+            include: "#class-or-trigger-members"
           }
         ]
       }
@@ -391,6 +403,58 @@ repository:
         name: "keyword.control.trigger.before.apex"
       "2":
         name: "keyword.control.trigger.after.apex"
+  "trigger-operator-statement":
+    name: "keyword.operator.trigger.apex"
+    match: "\\b(insert|update|delete|merge|upsert|undelete)\\b"
+  "trigger-context-declaration":
+    begin: "\\b(?:(Trigger))\\b(\\.)\\b"
+    beginCaptures:
+      "1":
+        name: "support.class.trigger.apex"
+      "2":
+        name: "punctuation.accessor.apex"
+    end: "(?=\\})|(?=;)|(?=\\)|(?=\\]))"
+    patterns: [
+      {
+        name: "support.type.trigger.apex"
+        match: "\\b(isExecuting|isInsert|isUpdate|isDelete|isBefore|isAfter|isUndelete|new|newMap|old|oldMap|size)\\b"
+      }
+      {
+        match: "(?:(\\.))([[:alpha:]]+)(?=\\()"
+        captures:
+          "1":
+            name: "punctuation.accessor.apex"
+          "2":
+            name: "support.function.trigger.apex"
+      }
+      {
+        begin: "\\("
+        beginCaptures:
+          "0":
+            name: "punctuation.parenthesis.open.apex"
+        end: "\\)"
+        endCaptures:
+          "0":
+            name: "punctuation.parenthesis.close.apex"
+        patterns: [
+          {
+            include: "#trigger-type-statement"
+          }
+          {
+            include: "#comment"
+          }
+          {
+            include: "#punctuation-comma"
+          }
+          {
+            include: "#expression"
+          }
+        ]
+      }
+      {
+        include: "#expression"
+      }
+    ]
   "enum-declaration":
     begin: "(?=\\benum\\b)"
     end: "(?<=\\})"
@@ -548,7 +612,13 @@ repository:
   "soql-query-body":
     patterns: [
       {
+        include: "#trigger-context-declaration"
+      }
+      {
         include: "#from-clause"
+      }
+      {
+        include: "#in-clause"
       }
       {
         include: "#where-clause"
@@ -570,6 +640,11 @@ repository:
         name: "keyword.operator.query.from.apex"
       "2":
         name: "storage.type.apex"
+  "in-clause":
+    match: "(IN)\\b\\s*"
+    captures:
+      "1":
+        name: "keyword.operator.query.in.apex"
   "where-clause":
     match: "\\b(WHERE)\\b\\s*"
     captures:
@@ -670,7 +745,7 @@ repository:
         include: "#variable-initializer"
       }
       {
-        include: "#class-or-struct-members"
+        include: "#class-or-trigger-members"
       }
     ]
   "property-declaration":
@@ -731,7 +806,7 @@ repository:
         include: "#variable-initializer"
       }
       {
-        include: "#class-or-struct-members"
+        include: "#class-or-trigger-members"
       }
     ]
   "indexer-declaration":

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,7 +50,7 @@ gulp.task('compile', function() {
 
 gulp.task('test', ['compile'], () => {
   return gulp
-    .src(jsOut + 'test/**/trigger.tests.js')
+    .src(jsOut + 'test/**/*.tests.js')
     .pipe(mocha())
     .on('error', handleError);
 });

--- a/src/apex.tmLanguage.yml
+++ b/src/apex.tmLanguage.yml
@@ -39,7 +39,7 @@ repository:
     - include: '#trigger-declaration'
     - include: '#punctuation-semicolon'
 
-  class-or-struct-members:
+  class-or-trigger-members:
     patterns:
     - include: '#comment'
     - include: '#storage-modifier'
@@ -85,6 +85,7 @@ repository:
     - include: '#comment'
     - include: '#throw-expression'
     - include: '#this-expression'
+    - include: '#trigger-context-declaration'
     - include: '#conditional-operator'
     - include: '#expression-operators'
     - include: '#soql-query-expression'
@@ -147,7 +148,7 @@ repository:
       endCaptures:
         '0': { name: punctuation.curlybrace.close.apex }
       patterns:
-      - include: '#class-or-struct-members'
+      - include: '#class-or-trigger-members'
     - include: '#comment'
 
   trigger-declaration:
@@ -175,6 +176,8 @@ repository:
           '0': { name: punctuation.parenthesis.close.apex }
         patterns:
         - include: '#trigger-type-statement'
+        - include: '#trigger-operator-statement'
+        - include: '#punctuation-comma'
         - include: '#expression'
       - include: '#comment'
       - include: '#type-parameter-list'
@@ -185,7 +188,8 @@ repository:
       endCaptures:
         '0': { name: punctuation.curlybrace.close.apex }
       patterns:
-      - include: '#class-or-struct-members'
+      - include: '#statement'
+      - include: '#class-or-trigger-members'
     - include: '#comment'
 
   trigger-type-statement:
@@ -193,6 +197,36 @@ repository:
     captures:
       '1': { name: keyword.control.trigger.before.apex }
       '2': { name: keyword.control.trigger.after.apex }
+
+  trigger-operator-statement:
+    name: 'keyword.operator.trigger.apex'
+    match: \b(insert|update|delete|merge|upsert|undelete)\b
+
+  trigger-context-declaration:
+    begin: \b(?:(Trigger))\b(\.)\b
+    beginCaptures:
+      '1': { name: support.class.trigger.apex }
+      '2': { name: punctuation.accessor.apex }
+    end: (?=\})|(?=;)|(?=\)|(?=\]))
+    patterns:
+    - name: support.type.trigger.apex
+      match: '\b(isExecuting|isInsert|isUpdate|isDelete|isBefore|isAfter|isUndelete|new|newMap|old|oldMap|size)\b'
+    - match: '(?:(\.))([[:alpha:]]+)(?=\()'
+      captures:
+        '1': { name: punctuation.accessor.apex }
+        '2': { name: support.function.trigger.apex}
+    - begin: \(
+      beginCaptures:
+        '0': { name: punctuation.parenthesis.open.apex }
+      end: \)
+      endCaptures:
+        '0': { name: punctuation.parenthesis.close.apex }
+      patterns:
+      - include: '#trigger-type-statement'
+      - include: '#comment'
+      - include: '#punctuation-comma'
+      - include: '#expression'
+    - include: '#expression'
 
   enum-declaration:
     begin: (?=\benum\b)
@@ -282,7 +316,9 @@ repository:
 
   soql-query-body:
     patterns:
+    - include: '#trigger-context-declaration'
     - include: '#from-clause'
+    - include: '#in-clause'
     - include: '#where-clause'
     - include: '#orderby-clause'
     - include: '#ordering-direction'
@@ -293,6 +329,11 @@ repository:
     captures:
       '1': { name: keyword.operator.query.from.apex }
       '2': { name: storage.type.apex }
+
+  in-clause:
+    match: (IN)\b\s*
+    captures:
+      '1': { name: keyword.operator.query.in.apex }
 
   where-clause:
     match: \b(WHERE)\b\s*
@@ -367,7 +408,7 @@ repository:
     - include: '#punctuation-comma'
     - include: '#comment'
     - include: '#variable-initializer'
-    - include: '#class-or-struct-members'
+    - include: '#class-or-trigger-members'
 
   property-declaration:
     begin: |-
@@ -412,7 +453,7 @@ repository:
     - include: '#property-accessors'
     - include: '#expression-body'
     - include: '#variable-initializer'
-    - include: '#class-or-struct-members'
+    - include: '#class-or-trigger-members'
 
   indexer-declaration:
     begin: |-

--- a/test/queries.tests.ts
+++ b/test/queries.tests.ts
@@ -213,5 +213,33 @@ describe('Grammar', () => {
         Token.Punctuation.Semicolon
       ]);
     });
+
+    it('simple query inside of brackets with where & in clause', () => {
+      const input = Input.InMethod(
+        `List<User> lUsers = [SELECT Id FROM User WHERE Id IN :variable];`
+      );
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Type('List'),
+        Token.Punctuation.TypeParameters.Begin,
+        Token.Type('User'),
+        Token.Punctuation.TypeParameters.End,
+        Token.Identifiers.LocalName('lUsers'),
+        Token.Operators.Assignment,
+        Token.Punctuation.OpenBracket,
+        Token.Keywords.Queries.Select,
+        Token.Keywords.Queries.FieldName('Id'),
+        Token.Keywords.Queries.From,
+        Token.Keywords.Queries.TypeName('User'),
+        Token.Keywords.Queries.Where,
+        Token.Keywords.Queries.FieldName('Id'),
+        Token.Keywords.Queries.In,
+        Token.Operators.Conditional.Colon,
+        Token.Keywords.Queries.FieldName('variable'),
+        Token.Punctuation.CloseBracket,
+        Token.Punctuation.Semicolon
+      ]);
+    });
   });
 });

--- a/test/statements.tests.ts
+++ b/test/statements.tests.ts
@@ -168,6 +168,24 @@ for (Integer i : listOfIntegers)
         ]);
       });
 
+      it('single-line if with operator and statement', () => {
+        const input = Input.InMethod(`if (true || Trigger.isBefore) return;`);
+        const tokens = tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.Keywords.Control.If,
+          Token.Punctuation.OpenParen,
+          Token.Literals.Boolean.True,
+          Token.Operators.Logical.Or,
+          Token.Support.Class.Trigger,
+          Token.Punctuation.Accessor,
+          Token.Support.Type.TriggerText('isBefore'),
+          Token.Punctuation.CloseParen,
+          Token.Keywords.Control.Return,
+          Token.Punctuation.Semicolon
+        ]);
+      });
+
       it('single-line if with embedded method call', () => {
         const input = Input.InMethod(`if (true) Do();`);
         const tokens = tokenize(input);

--- a/test/trigger.tests.ts
+++ b/test/trigger.tests.ts
@@ -6,7 +6,10 @@ describe('Grammar', () => {
 
   describe('Apex Trigger', () => {
     it('before insert before update Account trigger', () => {
-      const input = Input.FromText(`trigger myAccountTrigger on Account (before insert, before update) {}`);
+      const input = Input.FromText(`trigger myAccountTrigger on Account (before insert, after update) {
+        // Your code here
+        if(true) {}
+}`);
       const tokens = tokenize(input);
 
       tokens.should.deep.equal([
@@ -16,8 +19,139 @@ describe('Grammar', () => {
         Token.Type('Account'),
         Token.Punctuation.OpenParen,
         Token.Keywords.Triggers.Before,
+        Token.Keywords.Triggers.OperatorName('insert'),
+        Token.Punctuation.Comma,
+        Token.Keywords.Triggers.After,
+        Token.Keywords.Triggers.OperatorName('update'),
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.OpenBrace,
+        Token.Comment.LeadingWhitespace('        '),
+        Token.Comment.SingleLine.Start,
+        Token.Comment.SingleLine.Text(' Your code here'),
+        Token.Keywords.Control.If,
+        Token.Punctuation.OpenParen,
+        Token.Literals.Boolean.True,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.OpenBrace,
+        Token.Punctuation.CloseBrace,
+        Token.Punctuation.CloseBrace
+      ]);
+    });
+
+    it('context variables specific to triggers used in methods', () => {
+      const input = Input.InMethod(
+        `if (Trigger.isBefore && Trigger.isInsert) {}`
+      );
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Keywords.Control.If,
+        Token.Punctuation.OpenParen,
+        Token.Support.Class.Trigger,
+        Token.Punctuation.Accessor,
+        Token.Support.Type.TriggerText('isBefore'),
+        Token.Operators.Logical.And,
+        Token.Support.Class.Trigger,
+        Token.Punctuation.Accessor,
+        Token.Support.Type.TriggerText('isInsert'),
+        Token.Punctuation.CloseParen,
         Token.Punctuation.OpenBrace,
         Token.Punctuation.CloseBrace
+      ]);
+    });
+
+    it('context variables specific to triggers', () => {
+      const input = Input.InTrigger(
+        `if (Trigger.isBefore && Trigger.isInsert) {}`
+      );
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Keywords.Control.If,
+        Token.Punctuation.OpenParen,
+        Token.Support.Class.Trigger,
+        Token.Punctuation.Accessor,
+        Token.Support.Type.TriggerText('isBefore'),
+        Token.Operators.Logical.And,
+        Token.Support.Class.Trigger,
+        Token.Punctuation.Accessor,
+        Token.Support.Type.TriggerText('isInsert'),
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.OpenBrace,
+        Token.Punctuation.CloseBrace
+      ]);
+    });
+
+    it('triggers language specific functions', () => {
+      const input = Input.InTrigger(`Trigger.newMap.keySet();`);
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Support.Class.Trigger,
+        Token.Punctuation.Accessor,
+        Token.Support.Type.TriggerText('newMap'),
+        Token.Punctuation.Accessor,
+        Token.Support.Function.TriggerText('keySet'),
+        Token.Punctuation.OpenParen,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon
+      ]);
+    });
+
+    it('triggers language specific functions - complex scenario', () => {
+      const input = Input.InTrigger(
+        `Trigger.newMap.get(q.opportunity__c).addError('Cannot delete quote');`
+      );
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Support.Class.Trigger,
+        Token.Punctuation.Accessor,
+        Token.Support.Type.TriggerText('newMap'),
+        Token.Punctuation.Accessor,
+        Token.Support.Function.TriggerText('get'),
+        Token.Punctuation.OpenParen,
+        Token.Variables.Object('q'),
+        Token.Punctuation.Accessor,
+        Token.Variables.Property('opportunity__c'),
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Accessor,
+        Token.Support.Function.TriggerText('addError'),
+        Token.Punctuation.OpenParen,
+        Token.Punctuation.String.Begin,
+        Token.XmlDocComments.String.SingleQuoted.Text('Cannot delete quote'),
+        Token.Punctuation.String.End,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon
+      ]);
+    });
+
+    it('SOQL in triggers', () => {
+      const input = Input.InTrigger(
+        `Contact[] cons = [SELECT LastName FROM Contact WHERE AccountId IN :Trigger.new];`
+      );
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Type('Contact'),
+        Token.Punctuation.OpenBracket,
+        Token.Punctuation.CloseBracket,
+        Token.Identifiers.LocalName('cons'),
+        Token.Operators.Assignment,
+        Token.Punctuation.OpenBracket,
+        Token.Keywords.Queries.Select,
+        Token.Keywords.Queries.FieldName('LastName'),
+        Token.Keywords.Queries.From,
+        Token.Keywords.Queries.TypeName('Contact'),
+        Token.Keywords.Queries.Where,
+        Token.Keywords.Queries.FieldName('AccountId'),
+        Token.Keywords.Queries.In,
+        Token.Operators.Conditional.Colon,
+        Token.Support.Class.Trigger,
+        Token.Punctuation.Accessor,
+        Token.Support.Type.TriggerText('new'),
+        Token.Punctuation.CloseBracket,
+        Token.Punctuation.Semicolon
       ]);
     });
   });

--- a/test/utils/tokenize.ts
+++ b/test/utils/tokenize.ts
@@ -115,6 +115,24 @@ class TestClass {
     });
   }
 
+  public static InTrigger(input: string) {
+    let text = `
+trigger TestTrigger on Account (before insert, after update) {
+    ${input}
+}`;
+
+    // ensure consistent line-endings irrelevant of OS
+    text = text.replace('\r\n', '\n');
+    let lines = text.split('\n');
+
+    return new Input(lines, {
+      startLine: 2,
+      startIndex: 4,
+      endLine: lines.length - 1,
+      endIndex: 0
+    });
+  }
+
   public static InInterface(input: string) {
     let text = `
 interface TestInterface {
@@ -335,6 +353,7 @@ export namespace Token {
         'group',
         'keyword.operator.query.group.apex'
       );
+      export const In = createToken('IN', 'keyword.operator.query.in.apex');
       export const Into = createToken(
         'into',
         'keyword.operator.query.into.apex'
@@ -372,9 +391,17 @@ export namespace Token {
     }
 
     export namespace Triggers {
-      export const After = createToken('after', 'keyword.control.trigger.after.apex');
-      export const Before = createToken('before', 'keyword.control.trigger.before.apex');
+      export const After = createToken(
+        'after',
+        'keyword.control.trigger.after.apex'
+      );
+      export const Before = createToken(
+        'before',
+        'keyword.control.trigger.before.apex'
+      );
       export const On = createToken('on', 'keyword.operator.trigger.on.apex');
+      export const OperatorName = (text: string) =>
+        createToken(text, 'keyword.operator.trigger.apex');
     }
 
     export const Add = createToken('add', 'keyword.other.add.apex');
@@ -790,13 +817,24 @@ export namespace Token {
       export const Database = createToken('Database', 'support.class.apex');
       export const Exception = createToken('Exception', 'support.class.apex');
       export const System = createToken('System', 'support.class.apex');
+      export const Trigger = createToken(
+        'Trigger',
+        'support.class.trigger.apex'
+      );
       export const Text = (text: string) =>
         createToken(text, 'support.class.apex');
+    }
+
+    export namespace Type {
+      export const TriggerText = (text: string) =>
+        createToken(text, 'support.type.trigger.apex');
     }
 
     export namespace Function {
       export const Text = (text: string) =>
         createToken(text, 'support.function.apex');
+      export const TriggerText = (text: string) =>
+        createToken(text, 'support.function.trigger.apex');
       export const Insert = createToken('insert', 'support.function.apex');
     }
   }


### PR DESCRIPTION
Add tokenization rules for apex triggers. This targets trigger specific keywords (before, trigger, on, etc), context variables (Trigger.new, Trigger.isExecuting, etc) and its use in SOQL.

@W-4998647@