### PR TITLE
Move under @salesforce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apex-tmlanguage",
+  "name": "@salesforce/apex-tmlanguage",
   "version": "0.1.0",
   "description": "Textmate grammar for Apex with outputs for VSCode, Atom and TextMate.",
   "displayName": "apex-tmLanguage",


### PR DESCRIPTION
This makes it more consistent and easier for us to identify that this package comes from Salesforce.