### PR TITLE
Tokenize support functions used for object creation

### DIFF
--- a/grammars/apex.tmLanguage
+++ b/grammars/apex.tmLanguage
@@ -3766,13 +3766,18 @@
             <key>include</key>
             <string>#object-creation-expression-with-no-parameters</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#punctuation-comma</string>
+          </dict>
         </array>
       </dict>
       <key>object-creation-expression-with-parameters</key>
       <dict>
         <key>begin</key>
         <string>(?x)
-(new)\s+
+(delete|insert|undelete|update|upsert)?
+\s*(new)\s+
 (?&lt;type-name&gt;
   (?:
     (?:
@@ -3793,9 +3798,14 @@
           <key>1</key>
           <dict>
             <key>name</key>
-            <string>keyword.control.new.apex</string>
+            <string>support.function.apex</string>
           </dict>
           <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.new.apex</string>
+          </dict>
+          <key>3</key>
           <dict>
             <key>patterns</key>
             <array>
@@ -3824,7 +3834,8 @@
       <dict>
         <key>match</key>
         <string>(?x)
-(new)\s+
+(delete|insert|undelete|update|upsert)?
+\s*(new)\s+
 (?&lt;type-name&gt;
   (?:
     (?:
@@ -3845,9 +3856,14 @@
           <key>1</key>
           <dict>
             <key>name</key>
-            <string>keyword.control.new.apex</string>
+            <string>support.function.apex</string>
           </dict>
           <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.new.apex</string>
+          </dict>
+          <key>3</key>
           <dict>
             <key>patterns</key>
             <array>

--- a/grammars/apex.tmLanguage.cson
+++ b/grammars/apex.tmLanguage.cson
@@ -2200,11 +2200,15 @@ repository:
       {
         include: "#object-creation-expression-with-no-parameters"
       }
+      {
+        include: "#punctuation-comma"
+      }
     ]
   "object-creation-expression-with-parameters":
     begin: '''
       (?x)
-      (new)\\s+
+      (delete|insert|undelete|update|upsert)?
+      \\s*(new)\\s+
       (?<type-name>
         (?:
           (?:
@@ -2223,8 +2227,10 @@ repository:
     '''
     beginCaptures:
       "1":
-        name: "keyword.control.new.apex"
+        name: "support.function.apex"
       "2":
+        name: "keyword.control.new.apex"
+      "3":
         patterns: [
           {
             include: "#support-type"
@@ -2242,7 +2248,8 @@ repository:
   "object-creation-expression-with-no-parameters":
     match: '''
       (?x)
-      (new)\\s+
+      (delete|insert|undelete|update|upsert)?
+      \\s*(new)\\s+
       (?<type-name>
         (?:
           (?:
@@ -2261,8 +2268,10 @@ repository:
     '''
     captures:
       "1":
-        name: "keyword.control.new.apex"
+        name: "support.function.apex"
       "2":
+        name: "keyword.control.new.apex"
+      "3":
         patterns: [
           {
             include: "#support-type"

--- a/src/apex.tmLanguage.yml
+++ b/src/apex.tmLanguage.yml
@@ -1379,11 +1379,13 @@ repository:
     patterns:
     - include: '#object-creation-expression-with-parameters'
     - include: '#object-creation-expression-with-no-parameters'
+    - include: '#punctuation-comma'
 
   object-creation-expression-with-parameters:
     begin: |-
       (?x)
-      (new)\s+
+      (delete|insert|undelete|update|upsert)?
+      \s*(new)\s+
       (?<type-name>
         (?:
           (?:
@@ -1400,8 +1402,9 @@ repository:
       )\s*
       (?=\()
     beginCaptures:
-      '1': { name: keyword.control.new.apex }
-      '2':
+      '1': { name: support.function.apex }
+      '2': { name: keyword.control.new.apex }
+      '3':
         patterns:
         - include: '#support-type'
         - include: '#type'
@@ -1412,7 +1415,8 @@ repository:
   object-creation-expression-with-no-parameters:
     match: |-
       (?x)
-      (new)\s+
+      (delete|insert|undelete|update|upsert)?
+      \s*(new)\s+
       (?<type-name>
         (?:
           (?:
@@ -1429,8 +1433,9 @@ repository:
       )\s*
       (?=\{|$)
     captures:
-      '1': { name: keyword.control.new.apex }
-      '2':
+      '1': { name: support.function.apex }
+      '2': { name: keyword.control.new.apex }
+      '3':
         patterns:
         - include: '#support-type'
         - include: '#type'

--- a/test/system.tests.ts
+++ b/test/system.tests.ts
@@ -354,5 +354,66 @@ describe('Grammar', () => {
         Token.Punctuation.Semicolon
       ]);
     });
+
+    it('insert a new object with parameters', () => {
+      const input = Input.InMethod(
+        `insert new MyObject__c(Name='Test', Meaning__c='Bad');`
+      );
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Support.Class.FunctionText('insert'),
+        Token.Keywords.Control.New,
+        Token.Type('MyObject__c'),
+        Token.Punctuation.OpenParen,
+        Token.Variables.ReadWrite('Name'),
+        Token.Operators.Assignment,
+        Token.Punctuation.String.Begin,
+        Token.Literals.String('Test'),
+        Token.Punctuation.String.End,
+        Token.Punctuation.Comma,
+        Token.Variables.ReadWrite('Meaning__c'),
+        Token.Operators.Assignment,
+        Token.Punctuation.String.Begin,
+        Token.Literals.String('Bad'),
+        Token.Punctuation.String.End,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon
+      ]);
+    });
+
+    it('delete a new object with no parameters', () => {
+      const input = Input.InMethod(`delete new MyObjectWrapper());`);
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Support.Class.FunctionText('delete'),
+        Token.Keywords.Control.New,
+        Token.Type('MyObjectWrapper'),
+        Token.Punctuation.OpenParen,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon
+      ]);
+    });
+
+    it('upsert a new list of objects', () => {
+      const input = Input.InMethod(`upsert new List<User>{User1, User2});`);
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Support.Class.FunctionText('upsert'),
+        Token.Keywords.Control.New,
+        Token.Type('List'),
+        Token.Punctuation.TypeParameters.Begin,
+        Token.Type('User'),
+        Token.Punctuation.TypeParameters.End,
+        Token.Punctuation.OpenBrace,
+        Token.Variables.ReadWrite('User1'),
+        Token.Punctuation.Comma,
+        Token.Variables.ReadWrite('User2'),
+        Token.Punctuation.CloseBrace,
+        Token.Punctuation.Semicolon
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Correct tokenization of support functions when used together with 'new' keyword. Item tracked as @W-4997535@

e.g. `insert new CustomObject__c(Name='Test');`