### PR TITLE
Support for merge syntax

### DIFF
--- a/grammars/apex.tmLanguage
+++ b/grammars/apex.tmLanguage
@@ -279,6 +279,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#merge-expression</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#support-expression</string>
           </dict>
           <dict>
@@ -656,6 +660,63 @@
             <string>#punctuation-comma</string>
           </dict>
         </array>
+      </dict>
+      <key>merge-expression</key>
+      <dict>
+        <key>begin</key>
+        <string>(merge)\b\s+</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>support.function.apex</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(?&lt;=\;)</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#object-creation-expression</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#merge-type-statement</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#expression</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#punctuation-semicolon</string>
+          </dict>
+        </array>
+      </dict>
+      <key>merge-type-statement</key>
+      <dict>
+        <key>match</key>
+        <string>([_[:alpha:]]*)\b\s+([_[:alpha:]]*)\b\s*(\;)</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>variable.other.readwrite.apex</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>variable.other.readwrite.apex</string>
+          </dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.terminator.statement.apex</string>
+          </dict>
+        </dict>
       </dict>
       <key>sharing-modifier</key>
       <dict>

--- a/grammars/apex.tmLanguage.cson
+++ b/grammars/apex.tmLanguage.cson
@@ -192,6 +192,9 @@ repository:
         include: "#comment"
       }
       {
+        include: "#merge-expression"
+      }
+      {
         include: "#support-expression"
       }
       {
@@ -406,6 +409,35 @@ repository:
         include: "#punctuation-comma"
       }
     ]
+  "merge-expression":
+    begin: "(merge)\\b\\s+"
+    beginCaptures:
+      "1":
+        name: "support.function.apex"
+    end: "(?<=\\;)"
+    patterns: [
+      {
+        include: "#object-creation-expression"
+      }
+      {
+        include: "#merge-type-statement"
+      }
+      {
+        include: "#expression"
+      }
+      {
+        include: "#punctuation-semicolon"
+      }
+    ]
+  "merge-type-statement":
+    match: "([_[:alpha:]]*)\\b\\s+([_[:alpha:]]*)\\b\\s*(\\;)"
+    captures:
+      "1":
+        name: "variable.other.readwrite.apex"
+      "2":
+        name: "variable.other.readwrite.apex"
+      "3":
+        name: "punctuation.terminator.statement.apex"
   "sharing-modifier":
     name: "sharing.modifier.apex"
     match: "(?<!\\.)\\b(with sharing|without sharing)\\b"

--- a/src/apex.tmLanguage.yml
+++ b/src/apex.tmLanguage.yml
@@ -84,6 +84,7 @@ repository:
   expression:
     patterns:
     - include: '#comment'
+    - include: '#merge-expression'
     - include: '#support-expression'
     - include: '#throw-expression'
     - include: '#this-expression'
@@ -200,6 +201,24 @@ repository:
     - include: '#comment'
     - include: '#support-type'
     - include: '#punctuation-comma'
+
+  merge-expression:
+    begin: (merge)\b\s+
+    beginCaptures:
+      '1': { name: support.function.apex }
+    end: (?<=\;)
+    patterns:
+    - include: '#object-creation-expression'
+    - include: '#merge-type-statement'
+    - include: '#expression'
+    - include: '#punctuation-semicolon'
+
+  merge-type-statement:
+    match: ([_[:alpha:]]*)\b\s+([_[:alpha:]]*)\b\s*(\;)
+    captures:
+      '1': { name: variable.other.readwrite.apex }
+      '2': { name: variable.other.readwrite.apex }
+      '3': { name: punctuation.terminator.statement.apex }
 
   sharing-modifier:
     name: 'sharing.modifier.apex'

--- a/test/system.tests.ts
+++ b/test/system.tests.ts
@@ -397,7 +397,7 @@ describe('Grammar', () => {
     });
 
     it('upsert a new list of objects', () => {
-      const input = Input.InMethod(`upsert new List<User>{User1, User2});`);
+      const input = Input.InMethod(`upsert new List<User>{User1, User2};`);
       const tokens = tokenize(input);
 
       tokens.should.deep.equal([
@@ -411,6 +411,67 @@ describe('Grammar', () => {
         Token.Variables.ReadWrite('User1'),
         Token.Punctuation.Comma,
         Token.Variables.ReadWrite('User2'),
+        Token.Punctuation.CloseBrace,
+        Token.Punctuation.Semicolon
+      ]);
+    });
+
+    it('merge method usage in method', () => {
+      const input = Input.InMethod(`merge masterAcct mergeAcct;`);
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Support.Class.FunctionText('merge'),
+        Token.Variables.ReadWrite('masterAcct'),
+        Token.Variables.ReadWrite('mergeAcct'),
+        Token.Punctuation.Semicolon
+      ]);
+    });
+
+    it('merge 2', () => {
+      const input = Input.InMethod(`merge masterAcct new Account(name='Master');`);
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Support.Class.FunctionText('merge'),
+        Token.Variables.ReadWrite('masterAcct'),
+        Token.Keywords.Control.New,
+        Token.Type('Account'),
+        Token.Punctuation.OpenParen,
+        Token.Variables.ReadWrite('name'),
+        Token.Operators.Assignment,
+        Token.Punctuation.String.Begin,
+        Token.Literals.String('Master'),
+        Token.Punctuation.String.End,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon
+      ]);
+    });
+
+    it('merge 2', () => {
+      const input = Input.InMethod(`merge new Account(name='Master') new List<Account>{acc1, acc2};`);
+      const tokens = tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Support.Class.FunctionText('merge'),
+        Token.Keywords.Control.New,
+        Token.Type('Account'),
+        Token.Punctuation.OpenParen,
+        Token.Variables.ReadWrite('name'),
+        Token.Operators.Assignment,
+        Token.Punctuation.String.Begin,
+        Token.Literals.String('Master'),
+        Token.Punctuation.String.End,
+        Token.Punctuation.CloseParen,
+        Token.Keywords.Control.New,
+        Token.Type('List'),
+        Token.Punctuation.TypeParameters.Begin,
+        Token.Type('Account'),
+        Token.Punctuation.TypeParameters.End,
+        Token.Punctuation.OpenBrace,
+        Token.Variables.ReadWrite('acc1'),
+        Token.Punctuation.Comma,
+        Token.Variables.ReadWrite('acc2'),
         Token.Punctuation.CloseBrace,
         Token.Punctuation.Semicolon
       ]);


### PR DESCRIPTION
Add rule to properly highlight merge syntax. Tracked by @W-5093585@

**Before:**
<img width="332" alt="merge-before" src="https://user-images.githubusercontent.com/1041842/41567880-8083989e-7317-11e8-9e33-8f48a54db310.png">

**Now:**
<img width="405" alt="merge-now" src="https://user-images.githubusercontent.com/1041842/41567881-83e67f74-7317-11e8-8b09-2e4d827f3a0e.png">

<img width="409" alt="merge-using-new" src="https://user-images.githubusercontent.com/1041842/41567890-93676a3a-7317-11e8-924d-e1266ec949cf.png">
