### PR TITLE
Add Javadoc support in comments

### DIFF
--- a/grammars/apex.tmLanguage
+++ b/grammars/apex.tmLanguage
@@ -18,6 +18,10 @@
     <array>
       <dict>
         <key>include</key>
+        <string>#javadoc-comment</string>
+      </dict>
+      <dict>
+        <key>include</key>
         <string>#comment</string>
       </dict>
       <dict>
@@ -83,6 +87,10 @@
         <array>
           <dict>
             <key>include</key>
+            <string>#javadoc-comment</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#comment</string>
           </dict>
           <dict>
@@ -123,6 +131,10 @@
       <dict>
         <key>patterns</key>
         <array>
+          <dict>
+            <key>include</key>
+            <string>#javadoc-comment</string>
+          </dict>
           <dict>
             <key>include</key>
             <string>#comment</string>
@@ -173,6 +185,10 @@
       <dict>
         <key>patterns</key>
         <array>
+          <dict>
+            <key>include</key>
+            <string>#javadoc-comment</string>
+          </dict>
           <dict>
             <key>include</key>
             <string>#comment</string>
@@ -739,14 +755,14 @@
         <key>name</key>
         <string>sharing.modifier.apex</string>
         <key>match</key>
-        <string>(?&lt;!\.)\b(with sharing|without sharing)\b</string>
+        <string>(?&lt;!\.)\b(with sharing|without sharing|inherited sharing)\b</string>
       </dict>
       <key>storage-modifier</key>
       <dict>
         <key>name</key>
         <string>storage.modifier.apex</string>
         <key>match</key>
-        <string>(?&lt;!\.)\b(new|public|protected|private|abstract|virtual|override|global|static|final)\b</string>
+        <string>(?&lt;!\.)\b(new|public|protected|private|abstract|virtual|override|global|static|final|transient)\b</string>
       </dict>
       <key>class-declaration</key>
       <dict>
@@ -778,6 +794,10 @@
             <string>(?=\{)</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>include</key>
+                <string>#javadoc-comment</string>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>#comment</string>
@@ -824,6 +844,10 @@
                 <string>#class-or-trigger-members</string>
               </dict>
             </array>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#javadoc-comment</string>
           </dict>
           <dict>
             <key>include</key>
@@ -916,6 +940,10 @@
               </dict>
               <dict>
                 <key>include</key>
+                <string>#javadoc-comment</string>
+              </dict>
+              <dict>
+                <key>include</key>
                 <string>#comment</string>
               </dict>
               <dict>
@@ -956,6 +984,10 @@
                 <string>#class-or-trigger-members</string>
               </dict>
             </array>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#javadoc-comment</string>
           </dict>
           <dict>
             <key>include</key>
@@ -1061,11 +1093,11 @@
               </dict>
               <dict>
                 <key>include</key>
-                <string>#comment</string>
+                <string>#javadoc-comment</string>
               </dict>
               <dict>
                 <key>include</key>
-                <string>#punctuation-comma</string>
+                <string>#comment</string>
               </dict>
               <dict>
                 <key>include</key>
@@ -1094,6 +1126,10 @@
             <string>(?=\{)</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>include</key>
+                <string>#javadoc-comment</string>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>#comment</string>
@@ -1142,6 +1178,10 @@
             <array>
               <dict>
                 <key>include</key>
+                <string>#javadoc-comment</string>
+              </dict>
+              <dict>
+                <key>include</key>
                 <string>#comment</string>
               </dict>
               <dict>
@@ -1165,6 +1205,10 @@
                 <array>
                   <dict>
                     <key>include</key>
+                    <string>#javadoc-comment</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
                     <string>#comment</string>
                   </dict>
                   <dict>
@@ -1174,6 +1218,10 @@
                 </array>
               </dict>
             </array>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#javadoc-comment</string>
           </dict>
           <dict>
             <key>include</key>
@@ -1211,6 +1259,10 @@
             <string>(?=\{)</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>include</key>
+                <string>#javadoc-comment</string>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>#comment</string>
@@ -1253,6 +1305,10 @@
                 <string>#interface-members</string>
               </dict>
             </array>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#javadoc-comment</string>
           </dict>
           <dict>
             <key>include</key>
@@ -4581,6 +4637,113 @@
                 </dict>
                 <key>end</key>
                 <string>(?=$)</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>javadoc-comment</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>comment.block.javadoc.apex</string>
+            <key>begin</key>
+            <string>^\s*(/\*\*)(?!/)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.comment.apex</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>\*/</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.comment.apex</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>match</key>
+                <string>@(deprecated|return|see|serial|since|version|usage|name|link)\b</string>
+                <key>name</key>
+                <string>keyword.other.documentation.javadoc.apex</string>
+              </dict>
+              <dict>
+                <key>match</key>
+                <string>(@param)\s+(\S+)</string>
+                <key>captures</key>
+                <dict>
+                  <key>1</key>
+                  <dict>
+                    <key>name</key>
+                    <string>keyword.other.documentation.javadoc.apex</string>
+                  </dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>entity.name.variable.parameter.apex</string>
+                  </dict>
+                </dict>
+              </dict>
+              <dict>
+                <key>match</key>
+                <string>(@(?:exception|throws))\s+(\S+)</string>
+                <key>captures</key>
+                <dict>
+                  <key>1</key>
+                  <dict>
+                    <key>name</key>
+                    <string>keyword.other.documentation.javadoc.apex</string>
+                  </dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>entity.name.type.class.apex</string>
+                  </dict>
+                </dict>
+              </dict>
+              <dict>
+                <key>match</key>
+                <string>(@author)\s*([^&lt;]*)((&lt;)(\S+)(&gt;))?</string>
+                <key>captures</key>
+                <dict>
+                  <key>1</key>
+                  <dict>
+                    <key>name</key>
+                    <string>keyword.other.documentation.javadoc.apex</string>
+                  </dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>punctuation.definition.comment.apex</string>
+                  </dict>
+                  <key>3</key>
+                  <dict>
+                    <key>name</key>
+                    <string>keyword.other.documentation.javadoc.link.email</string>
+                  </dict>
+                </dict>
+              </dict>
+              <dict>
+                <key>match</key>
+                <string>(`([^`]+?)`)</string>
+                <key>captures</key>
+                <dict>
+                  <key>1</key>
+                  <dict>
+                    <key>name</key>
+                    <string>string.quoted.single.apex</string>
+                  </dict>
+                </dict>
               </dict>
             </array>
           </dict>

--- a/grammars/apex.tmLanguage.cson
+++ b/grammars/apex.tmLanguage.cson
@@ -8,6 +8,9 @@ fileTypes: [
 uuid: "F5FC6824-F257-43B1-B53A-14E1CCD18631"
 patterns: [
   {
+    include: "#javadoc-comment"
+  }
+  {
     include: "#comment"
   }
   {
@@ -51,6 +54,9 @@ repository:
   "type-declarations":
     patterns: [
       {
+        include: "#javadoc-comment"
+      }
+      {
         include: "#comment"
       }
       {
@@ -80,6 +86,9 @@ repository:
     ]
   "class-or-trigger-members":
     patterns: [
+      {
+        include: "#javadoc-comment"
+      }
       {
         include: "#comment"
       }
@@ -116,6 +125,9 @@ repository:
     ]
   "interface-members":
     patterns: [
+      {
+        include: "#javadoc-comment"
+      }
       {
         include: "#comment"
       }
@@ -452,10 +464,10 @@ repository:
         name: "punctuation.terminator.statement.apex"
   "sharing-modifier":
     name: "sharing.modifier.apex"
-    match: "(?<!\\.)\\b(with sharing|without sharing)\\b"
+    match: "(?<!\\.)\\b(with sharing|without sharing|inherited sharing)\\b"
   "storage-modifier":
     name: "storage.modifier.apex"
-    match: "(?<!\\.)\\b(new|public|protected|private|abstract|virtual|override|global|static|final)\\b"
+    match: "(?<!\\.)\\b(new|public|protected|private|abstract|virtual|override|global|static|final|transient)\\b"
   "class-declaration":
     begin: "(?=\\bclass\\b)"
     end: "(?<=\\})"
@@ -473,6 +485,9 @@ repository:
             name: "entity.name.type.class.apex"
         end: "(?=\\{)"
         patterns: [
+          {
+            include: "#javadoc-comment"
+          }
           {
             include: "#comment"
           }
@@ -501,6 +516,9 @@ repository:
             include: "#class-or-trigger-members"
           }
         ]
+      }
+      {
+        include: "#javadoc-comment"
       }
       {
         include: "#comment"
@@ -554,6 +572,9 @@ repository:
             ]
           }
           {
+            include: "#javadoc-comment"
+          }
+          {
             include: "#comment"
           }
           {
@@ -578,6 +599,9 @@ repository:
             include: "#class-or-trigger-members"
           }
         ]
+      }
+      {
+        include: "#javadoc-comment"
       }
       {
         include: "#comment"
@@ -628,10 +652,10 @@ repository:
             include: "#trigger-type-statement"
           }
           {
-            include: "#comment"
+            include: "#javadoc-comment"
           }
           {
-            include: "#punctuation-comma"
+            include: "#comment"
           }
           {
             include: "#expression"
@@ -650,6 +674,9 @@ repository:
         begin: "(?=enum)"
         end: "(?=\\{)"
         patterns: [
+          {
+            include: "#javadoc-comment"
+          }
           {
             include: "#comment"
           }
@@ -674,6 +701,9 @@ repository:
             name: "punctuation.curlybrace.close.apex"
         patterns: [
           {
+            include: "#javadoc-comment"
+          }
+          {
             include: "#comment"
           }
           {
@@ -687,6 +717,9 @@ repository:
             end: "(?=(,|\\}))"
             patterns: [
               {
+                include: "#javadoc-comment"
+              }
+              {
                 include: "#comment"
               }
               {
@@ -695,6 +728,9 @@ repository:
             ]
           }
         ]
+      }
+      {
+        include: "#javadoc-comment"
       }
       {
         include: "#comment"
@@ -717,6 +753,9 @@ repository:
             name: "entity.name.type.interface.apex"
         end: "(?=\\{)"
         patterns: [
+          {
+            include: "#javadoc-comment"
+          }
           {
             include: "#comment"
           }
@@ -742,6 +781,9 @@ repository:
             include: "#interface-members"
           }
         ]
+      }
+      {
+        include: "#javadoc-comment"
       }
       {
         include: "#comment"
@@ -2678,6 +2720,58 @@ repository:
               "0":
                 name: "punctuation.definition.comment.apex"
             end: "(?=$)"
+          }
+        ]
+      }
+    ]
+  "javadoc-comment":
+    patterns: [
+      {
+        name: "comment.block.javadoc.apex"
+        begin: "^\\s*(/\\*\\*)(?!/)"
+        beginCaptures:
+          "1":
+            name: "punctuation.definition.comment.apex"
+        end: "\\*/"
+        endCaptures:
+          "0":
+            name: "punctuation.definition.comment.apex"
+        patterns: [
+          {
+            match: "@(deprecated|return|see|serial|since|version|usage|name|link)\\b"
+            name: "keyword.other.documentation.javadoc.apex"
+          }
+          {
+            match: "(@param)\\s+(\\S+)"
+            captures:
+              "1":
+                name: "keyword.other.documentation.javadoc.apex"
+              "2":
+                name: "entity.name.variable.parameter.apex"
+          }
+          {
+            match: "(@(?:exception|throws))\\s+(\\S+)"
+            captures:
+              "1":
+                name: "keyword.other.documentation.javadoc.apex"
+              "2":
+                name: "entity.name.type.class.apex"
+          }
+          {
+            match: "(@author)\\s*([^<]*)((<)(\\S+)(>))?"
+            captures:
+              "1":
+                name: "keyword.other.documentation.javadoc.apex"
+              "2":
+                name: "punctuation.definition.comment.apex"
+              "3":
+                name: "keyword.other.documentation.javadoc.link.email"
+          }
+          {
+            match: "(`([^`]+?)`)"
+            captures:
+              "1":
+                name: "string.quoted.single.apex"
           }
         ]
       }

--- a/src/apex.tmLanguage.yml
+++ b/src/apex.tmLanguage.yml
@@ -6,6 +6,7 @@ fileTypes: [apex, cls, trigger]
 uuid: F5FC6824-F257-43B1-B53A-14E1CCD18631
 
 patterns:
+- include: '#javadoc-comment'
 - include: '#comment'
 - include: '#directives'
 - include: '#declarations'
@@ -29,6 +30,7 @@ repository:
 
   type-declarations:
     patterns:
+    - include: '#javadoc-comment'
     - include: '#comment'
     - include: '#annotation-declaration'
     - include: '#storage-modifier'
@@ -40,7 +42,8 @@ repository:
     - include: '#punctuation-semicolon'
 
   class-or-trigger-members:
-    patterns:
+    patterns:  
+    - include: '#javadoc-comment'
     - include: '#comment'
     - include: '#storage-modifier'
     - include: '#sharing-modifier'
@@ -54,7 +57,8 @@ repository:
     - include: '#punctuation-semicolon'
 
   interface-members:
-    patterns:
+    patterns:    
+    - include: '#javadoc-comment'
     - include: '#comment'
     - include: '#property-declaration'
     - include: '#indexer-declaration'
@@ -226,11 +230,11 @@ repository:
 
   sharing-modifier:
     name: 'sharing.modifier.apex'
-    match: (?<!\.)\b(with sharing|without sharing)\b
+    match: (?<!\.)\b(with sharing|without sharing|inherited sharing)\b
 
   storage-modifier:
     name: 'storage.modifier.apex'
-    match: (?<!\.)\b(new|public|protected|private|abstract|virtual|override|global|static|final)\b
+    match: (?<!\.)\b(new|public|protected|private|abstract|virtual|override|global|static|final|transient)\b
 
   class-declaration:
     begin: (?=\bclass\b)
@@ -245,6 +249,7 @@ repository:
         '2': { name: entity.name.type.class.apex }
       end: (?=\{)
       patterns:
+      - include: '#javadoc-comment'
       - include: '#comment'
       - include: '#type-parameter-list'
       - include: '#extends-class'
@@ -257,6 +262,7 @@ repository:
         '0': { name: punctuation.curlybrace.close.apex }
       patterns:
       - include: '#class-or-trigger-members'
+    - include: '#javadoc-comment'
     - include: '#comment'
 
   trigger-declaration:
@@ -287,6 +293,7 @@ repository:
         - include: '#trigger-operator-statement'
         - include: '#punctuation-comma'
         - include: '#expression'
+      - include: '#javadoc-comment'
       - include: '#comment'
       - include: '#type-parameter-list'
     - begin: \{
@@ -298,6 +305,7 @@ repository:
       patterns:
       - include: '#statement'
       - include: '#class-or-trigger-members'
+    - include: '#javadoc-comment'
     - include: '#comment'
 
   trigger-type-statement:
@@ -331,8 +339,8 @@ repository:
         '0': { name: punctuation.parenthesis.close.apex }
       patterns:
       - include: '#trigger-type-statement'
+      - include: '#javadoc-comment'
       - include: '#comment'
-      - include: '#punctuation-comma'
       - include: '#expression'
     - include: '#expression'
 
@@ -343,6 +351,7 @@ repository:
     - begin: (?=enum)
       end: (?=\{)
       patterns:
+      - include: '#javadoc-comment'
       - include: '#comment'
       - match: (enum)\s+(@?[_[:alpha:]][_[:alnum:]]*)
         captures:
@@ -355,6 +364,7 @@ repository:
       endCaptures:
         '0': { name: punctuation.curlybrace.close.apex }
       patterns:
+      - include: '#javadoc-comment'
       - include: '#comment'
       - include: '#punctuation-comma'
       - begin: '@?[_[:alpha:]][_[:alnum:]]*'
@@ -362,8 +372,10 @@ repository:
           '0': { name: entity.name.variable.enum-member.apex }
         end: (?=(,|\}))
         patterns:
+        - include: '#javadoc-comment'
         - include: '#comment'
         - include: '#variable-initializer'
+    - include: '#javadoc-comment'
     - include: '#comment'
 
   interface-declaration:
@@ -379,6 +391,7 @@ repository:
         '2': { name: entity.name.type.interface.apex }
       end: (?=\{)
       patterns:
+      - include: '#javadoc-comment'
       - include: '#comment'
       - include: '#type-parameter-list'
       - include: '#extends-class'
@@ -390,6 +403,7 @@ repository:
         '0': { name: punctuation.curlybrace.close.apex }
       patterns:
       - include: '#interface-members'
+    - include: '#javadoc-comment'
     - include: '#comment'
 
   extends-class:
@@ -1699,6 +1713,35 @@ repository:
         beginCaptures:
           '0': { name: punctuation.definition.comment.apex }
         end: (?=$)
+
+  javadoc-comment:
+    patterns:
+    - name: comment.block.javadoc.apex
+      begin: ^\s*(/\*\*)(?!/)
+      beginCaptures:
+        '1': { name: punctuation.definition.comment.apex }
+      end: \*/
+      endCaptures:
+        '0': { name: punctuation.definition.comment.apex }
+      patterns:
+      - match: "@(deprecated|return|see|serial|since|version|usage|name|link)\\b"
+        name: keyword.other.documentation.javadoc.apex
+      - match: (@param)\s+(\S+)
+        captures:
+          '1': { name: keyword.other.documentation.javadoc.apex }
+          '2': { name: entity.name.variable.parameter.apex }
+      - match: (@(?:exception|throws))\s+(\S+)
+        captures:
+          '1': { name: keyword.other.documentation.javadoc.apex }
+          '2': { name: entity.name.type.class.apex }
+      - match: (@author)\s*([^<]*)((<)(\S+)(>))?
+        captures:
+          '1': { name: keyword.other.documentation.javadoc.apex }
+          '2': { name: punctuation.definition.comment.apex }
+          '3': { name: keyword.other.documentation.javadoc.link.email }
+      - match: (`([^`]+?)`)
+        captures:
+          '1': { name: string.quoted.single.apex }
 
   xml-doc-comment:
     patterns:


### PR DESCRIPTION
As _APEX_ very similar to Java many projects use _Javadoc_ as a standard for class and method documentation. In the current grammer files Javadoc is not recognized/parsed as such non of the keywords are highlighted making class and method documentation harder to read then it should be. 

This change adds support for a basic highlighting of Javadoc for method, classes, interface, etc. Also there were a few missing keywords such as `transient` and `inherited sharing` which were not yet supported, these are added as well in this change.

How the highlighted code looks in VSCode:
![image](https://user-images.githubusercontent.com/787686/68758930-06685b80-060f-11ea-8463-f99df9f45605.png)
