### PR TITLE
Grammar Changes for Safe Navigation Operator (@W-7963330)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ To **build and test** install Node.js do the following:
 
 Output grammars are output in the `grammars\` dirctory.
 
+To see the token changes from within the Salesforce VS Code Extensions:
+
+1. Copy the `apex.tmLanguage` results into `../salesforcedx-vscode/packages/salesforcedx-vscode-apex/node_modules/@salesforce/apex-tmlanguage/grammars/apex.tmLanguage`.
+2. From the `Command Palette` select `Developer: Inspect Editor Tokens and Scopes`.
+
 ### Adding grammar rules
 
 Token structure is based off of [Textmate's Language Grammar guidelines](https://manual.macromates.com/en/language_grammars)

--- a/grammars/apex.tmLanguage
+++ b/grammars/apex.tmLanguage
@@ -1049,13 +1049,22 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?:(\.))([[:alpha:]]+)(?=\()</string>
+            <string>(?:(\??\.))([[:alpha:]]+)(?=\()</string>
             <key>captures</key>
             <dict>
               <key>1</key>
               <dict>
-                <key>name</key>
-                <string>punctuation.accessor.apex</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#punctuation-accessor</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>#operator-safe-navigation</string>
+                  </dict>
+                </array>
               </dict>
               <key>2</key>
               <dict>
@@ -1490,7 +1499,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?![_[:alnum:]]|\(|(\?)?\[|&lt;)</string>
+        <string>(?![_[:alnum:]]|\(|\[|&lt;)</string>
         <key>patterns</key>
         <array>
           <dict>
@@ -1499,7 +1508,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>([_[:alpha:]][_[:alnum:]]*)(\.)</string>
+            <string>([_[:alpha:]][_[:alnum:]]*)(\??\.)</string>
             <key>captures</key>
             <dict>
               <key>1</key>
@@ -1509,8 +1518,17 @@
               </dict>
               <key>2</key>
               <dict>
-                <key>name</key>
-                <string>punctuation.accessor.apex</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#punctuation-accessor</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>#operator-safe-navigation</string>
+                  </dict>
+                </array>
               </dict>
             </dict>
           </dict>
@@ -3838,7 +3856,7 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?:(\??\.)\s*)?                                  # safe navigation operator or accessor
+(?:(\??\.)\s*)?                                  # safe navigator or accessor
 (@?[_[:alpha:]][_[:alnum:]]*)\s*                 # method name
 (?&lt;type-args&gt;\s*&lt;([^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?\s* # type arguments
 (?=\()                                           # open paren of argument list</string>
@@ -3850,11 +3868,11 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#operator-safe-navigation</string>
+                <string>#punctuation-accessor</string>
               </dict>
               <dict>
                 <key>include</key>
-                <string>#punctuation.accessor.apex</string>
+                <string>#operator-safe-navigation</string>
               </dict>
             </array>
           </dict>
@@ -3888,7 +3906,7 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?:(\??\.)\s*)?                       # safe navigation operator or accessor
+(?:(\??\.)\s*)?                       # safe navigator or accessor
 (?:(@?[_[:alpha:]][_[:alnum:]]*)\s*)? # property name
 (?:(\?)\s*)?                          # null-conditional operator?
 (?=\[)                                # open bracket of argument list</string>
@@ -3900,11 +3918,11 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#operator-safe-navigation</string>
+                <string>#punctuation-accessor</string>
               </dict>
               <dict>
                 <key>include</key>
-                <string>#punctuation.accessor.apex</string>
+                <string>#operator-safe-navigation</string>
               </dict>
             </array>
           </dict>
@@ -3936,7 +3954,7 @@
           <dict>
             <key>match</key>
             <string>(?x)
-(?:(\??\.)\s*)?                  # safe navigation operator or accessor
+(\??\.)\s*                       # safe navigator or accessor
 (@?[_[:alpha:]][_[:alnum:]]*)\s* # property name
 (?![_[:alnum:]]|\(|(\?)?\[|&lt;)    # next character is not alpha-numeric, nor a (, [, or &lt;. Also, test for ?[</string>
             <key>captures</key>
@@ -3951,7 +3969,7 @@
                   </dict>
                   <dict>
                     <key>include</key>
-                    <string>#punctuation.accessor.apex</string>
+                    <string>#punctuation-accessor</string>
                   </dict>
                 </array>
               </dict>
@@ -3984,7 +4002,7 @@
                   </dict>
                   <dict>
                     <key>include</key>
-                    <string>#punctuation.accessor.apex</string>
+                    <string>#punctuation-accessor</string>
                   </dict>
                 </array>
               </dict>

--- a/grammars/apex.tmLanguage
+++ b/grammars/apex.tmLanguage
@@ -1499,7 +1499,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?![_[:alnum:]]|\(|\[|&lt;)</string>
+        <string>(?![_[:alnum:]]|\(|(\?)?\[|&lt;)</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/grammars/apex.tmLanguage
+++ b/grammars/apex.tmLanguage
@@ -3965,11 +3965,11 @@
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>#operator-safe-navigation</string>
+                    <string>#punctuation-accessor</string>
                   </dict>
                   <dict>
                     <key>include</key>
-                    <string>#punctuation-accessor</string>
+                    <string>#operator-safe-navigation</string>
                   </dict>
                 </array>
               </dict>
@@ -3998,11 +3998,11 @@
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>#operator-safe-navigation</string>
+                    <string>#punctuation-accessor</string>
                   </dict>
                   <dict>
                     <key>include</key>
-                    <string>#punctuation-accessor</string>
+                    <string>#operator-safe-navigation</string>
                   </dict>
                 </array>
               </dict>

--- a/grammars/apex.tmLanguage
+++ b/grammars/apex.tmLanguage
@@ -2645,7 +2645,7 @@
         <string>(?x)
 (switch)\b\s+
 (on)\b\s+
-(?:([_.\'\(\)[:alnum:]]+)\s*)?
+(?:([_.?\'\(\)[:alnum:]]+)\s*)?
 (\{)</string>
         <key>beginCaptures</key>
         <dict>
@@ -3838,29 +3838,32 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?:(\?)\s*)?                                     # preceding null-conditional operator?
-(?:(\.)\s*)?                                     # preceding dot?
-(@?[_[:alpha:]][_[:alnum:]]*)\s*                   # method name
+(?:(\??\.)\s*)?                                  # safe navigation operator or accessor
+(@?[_[:alpha:]][_[:alnum:]]*)\s*                 # method name
 (?&lt;type-args&gt;\s*&lt;([^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?\s* # type arguments
 (?=\()                                           # open paren of argument list</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
           <dict>
-            <key>name</key>
-            <string>keyword.operator.null-conditional.apex</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#operator-safe-navigation</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#punctuation.accessor.apex</string>
+              </dict>
+            </array>
           </dict>
           <key>2</key>
           <dict>
             <key>name</key>
-            <string>punctuation.accessor.apex</string>
-          </dict>
-          <key>3</key>
-          <dict>
-            <key>name</key>
             <string>entity.name.function.apex</string>
           </dict>
-          <key>4</key>
+          <key>3</key>
           <dict>
             <key>patterns</key>
             <array>
@@ -3885,29 +3888,32 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?:(\?)\s*)?                        # preceding null-conditional operator?
-(?:(\.)\s*)?                        # preceding dot?
+(?:(\??\.)\s*)?                       # safe navigation operator or accessor
 (?:(@?[_[:alpha:]][_[:alnum:]]*)\s*)? # property name
-(?:(\?)\s*)?                        # null-conditional operator?
-(?=\[)                              # open bracket of argument list</string>
+(?:(\?)\s*)?                          # null-conditional operator?
+(?=\[)                                # open bracket of argument list</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
           <dict>
-            <key>name</key>
-            <string>keyword.operator.null-conditional.apex</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#operator-safe-navigation</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#punctuation.accessor.apex</string>
+              </dict>
+            </array>
           </dict>
           <key>2</key>
           <dict>
             <key>name</key>
-            <string>punctuation.accessor.apex</string>
-          </dict>
-          <key>3</key>
-          <dict>
-            <key>name</key>
             <string>variable.other.object.property.apex</string>
           </dict>
-          <key>4</key>
+          <key>3</key>
           <dict>
             <key>name</key>
             <string>keyword.operator.null-conditional.apex</string>
@@ -3930,23 +3936,26 @@
           <dict>
             <key>match</key>
             <string>(?x)
-(?:(\?)\s*)?                   # preceding null-conditional operator?
-(\.)\s*                        # preceding dot
+(?:(\??\.)\s*)?                  # safe navigation operator or accessor
 (@?[_[:alpha:]][_[:alnum:]]*)\s* # property name
-(?![_[:alnum:]]|\(|(\?)?\[|&lt;)  # next character is not alpha-numeric, nor a (, [, or &lt;. Also, test for ?[</string>
+(?![_[:alnum:]]|\(|(\?)?\[|&lt;)    # next character is not alpha-numeric, nor a (, [, or &lt;. Also, test for ?[</string>
             <key>captures</key>
             <dict>
               <key>1</key>
               <dict>
-                <key>name</key>
-                <string>keyword.operator.null-conditional.apex</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#operator-safe-navigation</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>#punctuation.accessor.apex</string>
+                  </dict>
+                </array>
               </dict>
               <key>2</key>
-              <dict>
-                <key>name</key>
-                <string>punctuation.accessor.apex</string>
-              </dict>
-              <key>3</key>
               <dict>
                 <key>name</key>
                 <string>variable.other.object.property.apex</string>
@@ -3956,7 +3965,7 @@
           <dict>
             <key>match</key>
             <string>(?x)
-(\.)?\s*
+(\??\.)?\s*
 (@?[_[:alpha:]][_[:alnum:]]*)
 (?&lt;type-params&gt;\s*&lt;([^&lt;&gt;]|\g&lt;type-params&gt;)+&gt;\s*)
 (?=
@@ -3967,8 +3976,17 @@
             <dict>
               <key>1</key>
               <dict>
-                <key>name</key>
-                <string>punctuation.accessor.apex</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#operator-safe-navigation</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>#punctuation.accessor.apex</string>
+                  </dict>
+                </array>
               </dict>
               <key>2</key>
               <dict>
@@ -4563,6 +4581,13 @@
         <string>keyword.operator.assignment.apex</string>
         <key>match</key>
         <string>(?&lt;!=|!)(=)(?!=)</string>
+      </dict>
+      <key>operator-safe-navigation</key>
+      <dict>
+        <key>name</key>
+        <string>keyword.operator.safe-navigation.apex</string>
+        <key>match</key>
+        <string>\?\.</string>
       </dict>
       <key>punctuation-comma</key>
       <dict>

--- a/grammars/apex.tmLanguage.cson
+++ b/grammars/apex.tmLanguage.cson
@@ -896,7 +896,7 @@ repository:
     beginCaptures:
       "0":
         name: "keyword.operator.conditional.colon.apex"
-    end: "(?![_[:alnum:]]|\\(|\\[|<)"
+    end: "(?![_[:alnum:]]|\\(|(\\?)?\\[|<)"
     patterns: [
       {
         include: "#trigger-context-declaration"

--- a/grammars/apex.tmLanguage.cson
+++ b/grammars/apex.tmLanguage.cson
@@ -631,10 +631,17 @@ repository:
         match: "\\b(isExecuting|isInsert|isUpdate|isDelete|isBefore|isAfter|isUndelete|new|newMap|old|oldMap|size)\\b"
       }
       {
-        match: "(?:(\\.))([[:alpha:]]+)(?=\\()"
+        match: "(?:(\\??\\.))([[:alpha:]]+)(?=\\()"
         captures:
           "1":
-            name: "punctuation.accessor.apex"
+            patterns: [
+              {
+                include: "#punctuation-accessor"
+              }
+              {
+                include: "#operator-safe-navigation"
+              }
+            ]
           "2":
             name: "support.function.trigger.apex"
       }
@@ -889,18 +896,25 @@ repository:
     beginCaptures:
       "0":
         name: "keyword.operator.conditional.colon.apex"
-    end: "(?![_[:alnum:]]|\\(|(\\?)?\\[|<)"
+    end: "(?![_[:alnum:]]|\\(|\\[|<)"
     patterns: [
       {
         include: "#trigger-context-declaration"
       }
       {
-        match: "([_[:alpha:]][_[:alnum:]]*)(\\.)"
+        match: "([_[:alpha:]][_[:alnum:]]*)(\\??\\.)"
         captures:
           "1":
             name: "variable.other.object.apex"
           "2":
-            name: "punctuation.accessor.apex"
+            patterns: [
+              {
+                include: "#punctuation-accessor"
+              }
+              {
+                include: "#operator-safe-navigation"
+              }
+            ]
       }
       {
         include: "#soql-colon-method-statement"
@@ -2249,7 +2263,7 @@ repository:
   "invocation-expression":
     begin: '''
       (?x)
-      (?:(\\??\\.)\\s*)?                                  # safe navigation operator or accessor
+      (?:(\\??\\.)\\s*)?                                  # safe navigator or accessor
       (@?[_[:alpha:]][_[:alnum:]]*)\\s*                 # method name
       (?<type-args>\\s*<([^<>]|\\g<type-args>)+>\\s*)?\\s* # type arguments
       (?=\\()                                           # open paren of argument list
@@ -2258,10 +2272,10 @@ repository:
       "1":
         patterns: [
           {
-            include: "#operator-safe-navigation"
+            include: "#punctuation-accessor"
           }
           {
-            include: "#punctuation.accessor.apex"
+            include: "#operator-safe-navigation"
           }
         ]
       "2":
@@ -2281,7 +2295,7 @@ repository:
   "element-access-expression":
     begin: '''
       (?x)
-      (?:(\\??\\.)\\s*)?                       # safe navigation operator or accessor
+      (?:(\\??\\.)\\s*)?                       # safe navigator or accessor
       (?:(@?[_[:alpha:]][_[:alnum:]]*)\\s*)? # property name
       (?:(\\?)\\s*)?                          # null-conditional operator?
       (?=\\[)                                # open bracket of argument list
@@ -2290,10 +2304,10 @@ repository:
       "1":
         patterns: [
           {
-            include: "#operator-safe-navigation"
+            include: "#punctuation-accessor"
           }
           {
-            include: "#punctuation.accessor.apex"
+            include: "#operator-safe-navigation"
           }
         ]
       "2":
@@ -2311,7 +2325,7 @@ repository:
       {
         match: '''
           (?x)
-          (?:(\\??\\.)\\s*)?                  # safe navigation operator or accessor
+          (\\??\\.)\\s*                       # safe navigator or accessor
           (@?[_[:alpha:]][_[:alnum:]]*)\\s* # property name
           (?![_[:alnum:]]|\\(|(\\?)?\\[|<)    # next character is not alpha-numeric, nor a (, [, or <. Also, test for ?[
         '''
@@ -2322,7 +2336,7 @@ repository:
                 include: "#operator-safe-navigation"
               }
               {
-                include: "#punctuation.accessor.apex"
+                include: "#punctuation-accessor"
               }
             ]
           "2":
@@ -2346,7 +2360,7 @@ repository:
                 include: "#operator-safe-navigation"
               }
               {
-                include: "#punctuation.accessor.apex"
+                include: "#punctuation-accessor"
               }
             ]
           "2":

--- a/grammars/apex.tmLanguage.cson
+++ b/grammars/apex.tmLanguage.cson
@@ -2333,10 +2333,10 @@ repository:
           "1":
             patterns: [
               {
-                include: "#operator-safe-navigation"
+                include: "#punctuation-accessor"
               }
               {
-                include: "#punctuation-accessor"
+                include: "#operator-safe-navigation"
               }
             ]
           "2":
@@ -2357,10 +2357,10 @@ repository:
           "1":
             patterns: [
               {
-                include: "#operator-safe-navigation"
+                include: "#punctuation-accessor"
               }
               {
-                include: "#punctuation-accessor"
+                include: "#operator-safe-navigation"
               }
             ]
           "2":

--- a/grammars/apex.tmLanguage.cson
+++ b/grammars/apex.tmLanguage.cson
@@ -1555,7 +1555,7 @@ repository:
       (?x)
       (switch)\\b\\s+
       (on)\\b\\s+
-      (?:([_.\\'\\(\\)[:alnum:]]+)\\s*)?
+      (?:([_.?\\'\\(\\)[:alnum:]]+)\\s*)?
       (\\{)
     '''
     beginCaptures:
@@ -2249,20 +2249,24 @@ repository:
   "invocation-expression":
     begin: '''
       (?x)
-      (?:(\\?)\\s*)?                                     # preceding null-conditional operator?
-      (?:(\\.)\\s*)?                                     # preceding dot?
-      (@?[_[:alpha:]][_[:alnum:]]*)\\s*                   # method name
+      (?:(\\??\\.)\\s*)?                                  # safe navigation operator or accessor
+      (@?[_[:alpha:]][_[:alnum:]]*)\\s*                 # method name
       (?<type-args>\\s*<([^<>]|\\g<type-args>)+>\\s*)?\\s* # type arguments
       (?=\\()                                           # open paren of argument list
     '''
     beginCaptures:
       "1":
-        name: "keyword.operator.null-conditional.apex"
+        patterns: [
+          {
+            include: "#operator-safe-navigation"
+          }
+          {
+            include: "#punctuation.accessor.apex"
+          }
+        ]
       "2":
-        name: "punctuation.accessor.apex"
-      "3":
         name: "entity.name.function.apex"
-      "4":
+      "3":
         patterns: [
           {
             include: "#type-arguments"
@@ -2277,20 +2281,24 @@ repository:
   "element-access-expression":
     begin: '''
       (?x)
-      (?:(\\?)\\s*)?                        # preceding null-conditional operator?
-      (?:(\\.)\\s*)?                        # preceding dot?
+      (?:(\\??\\.)\\s*)?                       # safe navigation operator or accessor
       (?:(@?[_[:alpha:]][_[:alnum:]]*)\\s*)? # property name
-      (?:(\\?)\\s*)?                        # null-conditional operator?
-      (?=\\[)                              # open bracket of argument list
+      (?:(\\?)\\s*)?                          # null-conditional operator?
+      (?=\\[)                                # open bracket of argument list
     '''
     beginCaptures:
       "1":
-        name: "keyword.operator.null-conditional.apex"
+        patterns: [
+          {
+            include: "#operator-safe-navigation"
+          }
+          {
+            include: "#punctuation.accessor.apex"
+          }
+        ]
       "2":
-        name: "punctuation.accessor.apex"
-      "3":
         name: "variable.other.object.property.apex"
-      "4":
+      "3":
         name: "keyword.operator.null-conditional.apex"
     end: "(?<=\\])(?!\\s*\\[)"
     patterns: [
@@ -2303,23 +2311,27 @@ repository:
       {
         match: '''
           (?x)
-          (?:(\\?)\\s*)?                   # preceding null-conditional operator?
-          (\\.)\\s*                        # preceding dot
+          (?:(\\??\\.)\\s*)?                  # safe navigation operator or accessor
           (@?[_[:alpha:]][_[:alnum:]]*)\\s* # property name
-          (?![_[:alnum:]]|\\(|(\\?)?\\[|<)  # next character is not alpha-numeric, nor a (, [, or <. Also, test for ?[
+          (?![_[:alnum:]]|\\(|(\\?)?\\[|<)    # next character is not alpha-numeric, nor a (, [, or <. Also, test for ?[
         '''
         captures:
           "1":
-            name: "keyword.operator.null-conditional.apex"
+            patterns: [
+              {
+                include: "#operator-safe-navigation"
+              }
+              {
+                include: "#punctuation.accessor.apex"
+              }
+            ]
           "2":
-            name: "punctuation.accessor.apex"
-          "3":
             name: "variable.other.object.property.apex"
       }
       {
         match: '''
           (?x)
-          (\\.)?\\s*
+          (\\??\\.)?\\s*
           (@?[_[:alpha:]][_[:alnum:]]*)
           (?<type-params>\\s*<([^<>]|\\g<type-params>)+>\\s*)
           (?=
@@ -2329,7 +2341,14 @@ repository:
         '''
         captures:
           "1":
-            name: "punctuation.accessor.apex"
+            patterns: [
+              {
+                include: "#operator-safe-navigation"
+              }
+              {
+                include: "#punctuation.accessor.apex"
+              }
+            ]
           "2":
             name: "variable.other.object.apex"
           "3":
@@ -2688,6 +2707,9 @@ repository:
   "operator-assignment":
     name: "keyword.operator.assignment.apex"
     match: "(?<!=|!)(=)(?!=)"
+  "operator-safe-navigation":
+    name: "keyword.operator.safe-navigation.apex"
+    match: "\\?\\."
   "punctuation-comma":
     name: "punctuation.separator.comma.apex"
     match: ","

--- a/src/apex.tmLanguage.yml
+++ b/src/apex.tmLanguage.yml
@@ -910,7 +910,7 @@ repository:
       (?x)
       (switch)\b\s+
       (on)\b\s+
-      (?:([_.\'\(\)[:alnum:]]+)\s*)?
+      (?:([_.?\'\(\)[:alnum:]]+)\s*)?
       (\{)
     beginCaptures:
       '1': { name: keyword.control.switch.apex }
@@ -1378,16 +1378,17 @@ repository:
   invocation-expression:
     begin: |-
       (?x)
-      (?:(\?)\s*)?                                     # preceding null-conditional operator?
-      (?:(\.)\s*)?                                     # preceding dot?
-      (@?[_[:alpha:]][_[:alnum:]]*)\s*                   # method name
+      (?:(\??\.)\s*)?                                  # safe navigation operator or accessor
+      (@?[_[:alpha:]][_[:alnum:]]*)\s*                 # method name
       (?<type-args>\s*<([^<>]|\g<type-args>)+>\s*)?\s* # type arguments
       (?=\()                                           # open paren of argument list
     beginCaptures:
-      '1': { name: keyword.operator.null-conditional.apex }
-      '2': { name: punctuation.accessor.apex }
-      '3': { name: entity.name.function.apex }
-      '4':
+      '1':
+        patterns:
+          - include: '#operator-safe-navigation'
+          - include: '#punctuation.accessor.apex'
+      '2': { name: entity.name.function.apex }
+      '3':
         patterns:
         - include: '#type-arguments'
     end: (?<=\))
@@ -1397,16 +1398,17 @@ repository:
   element-access-expression:
     begin: |-
       (?x)
-      (?:(\?)\s*)?                        # preceding null-conditional operator?
-      (?:(\.)\s*)?                        # preceding dot?
+      (?:(\??\.)\s*)?                       # safe navigation operator or accessor
       (?:(@?[_[:alpha:]][_[:alnum:]]*)\s*)? # property name
-      (?:(\?)\s*)?                        # null-conditional operator?
-      (?=\[)                              # open bracket of argument list
+      (?:(\?)\s*)?                          # null-conditional operator?
+      (?=\[)                                # open bracket of argument list
     beginCaptures:
-      '1': { name: keyword.operator.null-conditional.apex }
-      '2': { name: punctuation.accessor.apex }
-      '3': { name: variable.other.object.property.apex }
-      '4': { name: keyword.operator.null-conditional.apex }
+      '1':
+        patterns:
+          - include: '#operator-safe-navigation'
+          - include: '#punctuation.accessor.apex'
+      '2': { name: variable.other.object.property.apex }
+      '3': { name: keyword.operator.null-conditional.apex }
     end: (?<=\])(?!\s*\[)
     patterns:
     - include: '#bracketed-argument-list'
@@ -1417,19 +1419,20 @@ repository:
       # be treated as a property, so long as it isn't followed by a ( or [.
     - match: |-
         (?x)
-        (?:(\?)\s*)?                   # preceding null-conditional operator?
-        (\.)\s*                        # preceding dot
+        (?:(\??\.)\s*)?                  # safe navigation operator or accessor
         (@?[_[:alpha:]][_[:alnum:]]*)\s* # property name
-        (?![_[:alnum:]]|\(|(\?)?\[|<)  # next character is not alpha-numeric, nor a (, [, or <. Also, test for ?[
+        (?![_[:alnum:]]|\(|(\?)?\[|<)    # next character is not alpha-numeric, nor a (, [, or <. Also, test for ?[
       captures:
-        '1': { name: keyword.operator.null-conditional.apex }
-        '2': { name: punctuation.accessor.apex }
-        '3': { name: variable.other.object.property.apex }
+        '1':
+          patterns:
+            - include: '#operator-safe-navigation'
+            - include: '#punctuation.accessor.apex'
+        '2': { name: variable.other.object.property.apex }
       # An identifier with type parameters should be treated as an object,
       # regardless of whether there is a dot to the left.
     - match: |-
         (?x)
-        (\.)?\s*
+        (\??\.)?\s*
         (@?[_[:alpha:]][_[:alnum:]]*)
         (?<type-params>\s*<([^<>]|\g<type-params>)+>\s*)
         (?=
@@ -1437,7 +1440,10 @@ repository:
           \s*\.\s*@?[_[:alpha:]][_[:alnum:]]*
         )
       captures:
-        '1': { name: punctuation.accessor.apex }
+        '1':
+          patterns:
+          - include: '#operator-safe-navigation'
+          - include: '#punctuation.accessor.apex'
         '2': { name: variable.other.object.apex }
         '3':
           patterns:
@@ -1685,6 +1691,10 @@ repository:
   operator-assignment:
     name: keyword.operator.assignment.apex
     match: (?<!=|!)(=)(?!=)
+
+  operator-safe-navigation:
+    name: keyword.operator.safe-navigation.apex
+    match: '\?\.'
 
   punctuation-comma:
     name: punctuation.separator.comma.apex

--- a/src/apex.tmLanguage.yml
+++ b/src/apex.tmLanguage.yml
@@ -1431,8 +1431,8 @@ repository:
       captures:
         '1':
           patterns:
-          - include: '#operator-safe-navigation'
           - include: '#punctuation-accessor'
+          - include: '#operator-safe-navigation'
         '2': { name: variable.other.object.property.apex }
       # An identifier with type parameters should be treated as an object,
       # regardless of whether there is a dot to the left.
@@ -1448,8 +1448,8 @@ repository:
       captures:
         '1':
           patterns:
-          - include: '#operator-safe-navigation'
           - include: '#punctuation-accessor'
+          - include: '#operator-safe-navigation'
         '2': { name: variable.other.object.apex }
         '3':
           patterns:

--- a/src/apex.tmLanguage.yml
+++ b/src/apex.tmLanguage.yml
@@ -461,7 +461,7 @@ repository:
     begin: (\:)\s* # preceding colon operator
     beginCaptures:
       '0': { name: keyword.operator.conditional.colon.apex }
-    end: (?![_[:alnum:]]|\(|\[|<)  # next character is not alpha-numeric, nor a (, [, or <.
+    end: (?![_[:alnum:]]|\(|(\?)?\[|<)  # next character is not alpha-numeric, nor a (, [, or <. Also, test for ?[
     patterns:
     - include: '#trigger-context-declaration'
     - match: ([_[:alpha:]][_[:alnum:]]*)(\??\.)

--- a/src/apex.tmLanguage.yml
+++ b/src/apex.tmLanguage.yml
@@ -327,9 +327,12 @@ repository:
     patterns:
     - name: support.type.trigger.apex
       match: '\b(isExecuting|isInsert|isUpdate|isDelete|isBefore|isAfter|isUndelete|new|newMap|old|oldMap|size)\b'
-    - match: '(?:(\.))([[:alpha:]]+)(?=\()'
+    - match: '(?:(\??\.))([[:alpha:]]+)(?=\()'
       captures:
-        '1': { name: punctuation.accessor.apex }
+        '1':
+          patterns:
+          - include: '#punctuation-accessor'
+          - include: '#operator-safe-navigation'
         '2': { name: support.function.trigger.apex}
     - begin: \(
       beginCaptures:
@@ -458,13 +461,16 @@ repository:
     begin: (\:)\s* # preceding colon operator
     beginCaptures:
       '0': { name: keyword.operator.conditional.colon.apex }
-    end: (?![_[:alnum:]]|\(|(\?)?\[|<)  # next character is not alpha-numeric, nor a (, [, or <. Also, test for ?[
+    end: (?![_[:alnum:]]|\(|\[|<)  # next character is not alpha-numeric, nor a (, [, or <.
     patterns:
     - include: '#trigger-context-declaration'
-    - match: ([_[:alpha:]][_[:alnum:]]*)(\.)
+    - match: ([_[:alpha:]][_[:alnum:]]*)(\??\.)
       captures:
         '1': { name: variable.other.object.apex}
-        '2': { name: punctuation.accessor.apex }
+        '2': 
+          patterns:
+          - include: '#punctuation-accessor'
+          - include: '#operator-safe-navigation'
     - include: '#soql-colon-method-statement'
     - name: entity.name.variable.local.apex
       match: '[_[:alpha:]][_[:alnum:]]*'
@@ -1378,15 +1384,15 @@ repository:
   invocation-expression:
     begin: |-
       (?x)
-      (?:(\??\.)\s*)?                                  # safe navigation operator or accessor
+      (?:(\??\.)\s*)?                                  # safe navigator or accessor
       (@?[_[:alpha:]][_[:alnum:]]*)\s*                 # method name
       (?<type-args>\s*<([^<>]|\g<type-args>)+>\s*)?\s* # type arguments
       (?=\()                                           # open paren of argument list
     beginCaptures:
       '1':
         patterns:
-          - include: '#operator-safe-navigation'
-          - include: '#punctuation.accessor.apex'
+        - include: '#punctuation-accessor'
+        - include: '#operator-safe-navigation'
       '2': { name: entity.name.function.apex }
       '3':
         patterns:
@@ -1398,15 +1404,15 @@ repository:
   element-access-expression:
     begin: |-
       (?x)
-      (?:(\??\.)\s*)?                       # safe navigation operator or accessor
+      (?:(\??\.)\s*)?                       # safe navigator or accessor
       (?:(@?[_[:alpha:]][_[:alnum:]]*)\s*)? # property name
       (?:(\?)\s*)?                          # null-conditional operator?
       (?=\[)                                # open bracket of argument list
     beginCaptures:
       '1':
         patterns:
-          - include: '#operator-safe-navigation'
-          - include: '#punctuation.accessor.apex'
+        - include: '#punctuation-accessor'
+        - include: '#operator-safe-navigation'
       '2': { name: variable.other.object.property.apex }
       '3': { name: keyword.operator.null-conditional.apex }
     end: (?<=\])(?!\s*\[)
@@ -1419,14 +1425,14 @@ repository:
       # be treated as a property, so long as it isn't followed by a ( or [.
     - match: |-
         (?x)
-        (?:(\??\.)\s*)?                  # safe navigation operator or accessor
+        (\??\.)\s*                       # safe navigator or accessor
         (@?[_[:alpha:]][_[:alnum:]]*)\s* # property name
         (?![_[:alnum:]]|\(|(\?)?\[|<)    # next character is not alpha-numeric, nor a (, [, or <. Also, test for ?[
       captures:
         '1':
           patterns:
-            - include: '#operator-safe-navigation'
-            - include: '#punctuation.accessor.apex'
+          - include: '#operator-safe-navigation'
+          - include: '#punctuation-accessor'
         '2': { name: variable.other.object.property.apex }
       # An identifier with type parameters should be treated as an object,
       # regardless of whether there is a dot to the left.
@@ -1443,7 +1449,7 @@ repository:
         '1':
           patterns:
           - include: '#operator-safe-navigation'
-          - include: '#punctuation.accessor.apex'
+          - include: '#punctuation-accessor'
         '2': { name: variable.other.object.apex }
         '3':
           patterns:

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -300,7 +300,7 @@ Object newPoint = new Vector(point.x * z, 0);`);
         ]);
       });
 
-      it('member with two element accesses with Safe Navigator', async () => {
+      it('member with two element accesses with safe navigator', async () => {
         const input = Input.InMethod(`Object a = b?.c[19][23];`);
         const tokens = await tokenize(input);
 

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -61,6 +61,28 @@ Object newPoint = new Vector(point.x * z, 0);`);
           Token.Punctuation.Semicolon
         ]);
       });
+
+      it('mixed relational and arithmetic operators with safe navigator', async () => {
+        const input = Input.InMethod(`b = this?.i != 1 + (2 - 3);`);
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.Variables.ReadWrite('b'),
+          Token.Operators.Assignment,
+          Token.Keywords.This,
+          Token.Operators.SafeNavigation,
+          Token.Variables.Property('i'),
+          Token.Operators.Relational.NotEqual,
+          Token.Literals.Numeric.Decimal('1'),
+          Token.Operators.Arithmetic.Addition,
+          Token.Punctuation.OpenParen,
+          Token.Literals.Numeric.Decimal('2'),
+          Token.Operators.Arithmetic.Subtraction,
+          Token.Literals.Numeric.Decimal('3'),
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.Semicolon
+        ]);
+      });
     });
 
     describe('Casts', () => {
@@ -239,6 +261,24 @@ Object newPoint = new Vector(point.x * z, 0);`);
         ]);
       });
 
+      it('member with element access with safe navigator', async () => {
+        const input = Input.InMethod(`Object a = b?.c[0];`);
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.PrimitiveType.Object,
+          Token.Identifiers.LocalName('a'),
+          Token.Operators.Assignment,
+          Token.Variables.Object('b'),
+          Token.Operators.SafeNavigation,
+          Token.Variables.Property('c'),
+          Token.Punctuation.OpenBracket,
+          Token.Literals.Numeric.Decimal('0'),
+          Token.Punctuation.CloseBracket,
+          Token.Punctuation.Semicolon
+        ]);
+      });
+
       it('member with two element accesses', async () => {
         const input = Input.InMethod(`Object a = b.c[19][23];`);
         const tokens = await tokenize(input);
@@ -249,6 +289,27 @@ Object newPoint = new Vector(point.x * z, 0);`);
           Token.Operators.Assignment,
           Token.Variables.Object('b'),
           Token.Punctuation.Accessor,
+          Token.Variables.Property('c'),
+          Token.Punctuation.OpenBracket,
+          Token.Literals.Numeric.Decimal('19'),
+          Token.Punctuation.CloseBracket,
+          Token.Punctuation.OpenBracket,
+          Token.Literals.Numeric.Decimal('23'),
+          Token.Punctuation.CloseBracket,
+          Token.Punctuation.Semicolon
+        ]);
+      });
+
+      it('member with two element accesses with Safe Navigator', async () => {
+        const input = Input.InMethod(`Object a = b?.c[19][23];`);
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.PrimitiveType.Object,
+          Token.Identifiers.LocalName('a'),
+          Token.Operators.Assignment,
+          Token.Variables.Object('b'),
+          Token.Operators.SafeNavigation,
           Token.Variables.Property('c'),
           Token.Punctuation.OpenBracket,
           Token.Literals.Numeric.Decimal('19'),
@@ -283,6 +344,29 @@ Object newPoint = new Vector(point.x * z, 0);`);
         ]);
       });
 
+      it('member with two element accesses and another member with safe navigator', async () => {
+        const input = Input.InMethod(`Object a = b.c[19][23]?.d;`);
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.PrimitiveType.Object,
+          Token.Identifiers.LocalName('a'),
+          Token.Operators.Assignment,
+          Token.Variables.Object('b'),
+          Token.Punctuation.Accessor,
+          Token.Variables.Property('c'),
+          Token.Punctuation.OpenBracket,
+          Token.Literals.Numeric.Decimal('19'),
+          Token.Punctuation.CloseBracket,
+          Token.Punctuation.OpenBracket,
+          Token.Literals.Numeric.Decimal('23'),
+          Token.Punctuation.CloseBracket,
+          Token.Operators.SafeNavigation,
+          Token.Variables.Property('d'),
+          Token.Punctuation.Semicolon
+        ]);
+      });
+
       it('member with two element accesses and an invocation', async () => {
         const input = Input.InMethod(`Object a = b.c[19][23].d();`);
         const tokens = await tokenize(input);
@@ -301,6 +385,31 @@ Object newPoint = new Vector(point.x * z, 0);`);
           Token.Literals.Numeric.Decimal('23'),
           Token.Punctuation.CloseBracket,
           Token.Punctuation.Accessor,
+          Token.Identifiers.MethodName('d'),
+          Token.Punctuation.OpenParen,
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.Semicolon
+        ]);
+      });
+
+      it('member with two element accesses and an invocation with safe navigator', async () => {
+        const input = Input.InMethod(`Object a = b.c[19][23]?.d();`);
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.PrimitiveType.Object,
+          Token.Identifiers.LocalName('a'),
+          Token.Operators.Assignment,
+          Token.Variables.Object('b'),
+          Token.Punctuation.Accessor,
+          Token.Variables.Property('c'),
+          Token.Punctuation.OpenBracket,
+          Token.Literals.Numeric.Decimal('19'),
+          Token.Punctuation.CloseBracket,
+          Token.Punctuation.OpenBracket,
+          Token.Literals.Numeric.Decimal('23'),
+          Token.Punctuation.CloseBracket,
+          Token.Operators.SafeNavigation,
           Token.Identifiers.MethodName('d'),
           Token.Punctuation.OpenParen,
           Token.Punctuation.CloseParen,
@@ -679,6 +788,22 @@ Long total = data['bonusGame']['win'].AsLong * data['bonusGame']['betMult'].AsLo
           Token.Punctuation.OpenParen,
           Token.Punctuation.CloseParen,
           Token.Punctuation.Accessor,
+          Token.Identifiers.MethodName('M2'),
+          Token.Punctuation.OpenParen,
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.Semicolon
+        ]);
+      });
+
+      it('chained method calls with safe navigator', async () => {
+        const input = Input.InMethod(`M1()?.M2();`);
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.Identifiers.MethodName('M1'),
+          Token.Punctuation.OpenParen,
+          Token.Punctuation.CloseParen,
+          Token.Operators.SafeNavigation,
           Token.Identifiers.MethodName('M2'),
           Token.Punctuation.OpenParen,
           Token.Punctuation.CloseParen,

--- a/test/for-statements.tests.ts
+++ b/test/for-statements.tests.ts
@@ -222,6 +222,32 @@ for (Integer i : listOfIntegers)
       ]);
     });
 
+    it('for loop or an object with safe navigator', async () => {
+      const input = Input.InMethod(`
+  for (SObject myFancyObject : myObject?.WithMethod()){
+    break;
+  }`);
+      const tokens = await tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Keywords.Control.For,
+        Token.Punctuation.OpenParen,
+        Token.Support.Class.Text('SObject'),
+        Token.Identifiers.LocalName('myFancyObject'),
+        Token.Keywords.Control.ColonIterator,
+        Token.Variables.Object('myObject'),
+        Token.Operators.SafeNavigation,
+        Token.Identifiers.MethodName('WithMethod'),
+        Token.Punctuation.OpenParen,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.OpenBrace,
+        Token.Keywords.Control.Break,
+        Token.Punctuation.Semicolon,
+        Token.Punctuation.CloseBrace
+      ]);
+    });
+
     it('for loop a query that uses local variables', async () => {
       const input = Input.InMethod(`
   for (SObject myFancyObject : [SELECT Id, Name FROM User WHERE Id IN :variable]){

--- a/test/switch.tests.ts
+++ b/test/switch.tests.ts
@@ -54,7 +54,7 @@ when else {
       ]);
     });
 
-    it('simple switch with save navigator', async () => {
+    it('simple switch with safe navigator', async () => {
       const input = Input.InMethod(`
 switch on (obj?.param) {
 when 'A' {
@@ -470,7 +470,7 @@ when else {
       ]);
     });
 
-    it('simple - method example with Safe Navigator', async () => {
+    it('simple - method example with safe navigator', async () => {
       const input = Input.InMethod(`
         switch on obj?.someInteger(i) {
    when 2,3,4 {

--- a/test/switch.tests.ts
+++ b/test/switch.tests.ts
@@ -56,7 +56,7 @@ when else {
 
     it('simple switch with save navigator', async () => {
       const input = Input.InMethod(`
-switch on obj?.param {
+switch on (obj?.param) {
 when 'A' {
   System.debug('test');
 }
@@ -70,7 +70,9 @@ when else {
         Token.Keywords.Switch.Switch,
         Token.Keywords.Switch.On,
         Token.Punctuation.OpenParen,
-        Token.Variables.ReadWrite('param'),
+        Token.Variables.Object('obj'),
+        Token.Operators.SafeNavigation,
+        Token.Variables.Property('param'),
         Token.Punctuation.CloseParen,
         Token.Punctuation.OpenBrace,
         Token.Keywords.Switch.When,
@@ -159,7 +161,6 @@ System.debug('test');`);
       ]);
     });
 
-    // TODO - may need to test a scenario like this too
     it('multiple string switch', async () => {
       const input = Input.InMethod(`
 switch on (param) {
@@ -403,7 +404,6 @@ when else {
       ]);
     });
 
-    // TODO - may also need an example here
     it('simple - method example', async () => {
       const input = Input.InMethod(`
         switch on someInteger(i) {
@@ -422,6 +422,74 @@ when else {
       tokens.should.deep.equal([
         Token.Keywords.Switch.Switch,
         Token.Keywords.Switch.On,
+        Token.Identifiers.MethodName('someInteger'),
+        Token.Punctuation.OpenParen,
+        Token.Variables.ReadWrite('i'),
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.OpenBrace,
+        Token.Keywords.Switch.When,
+        Token.Literals.Numeric.Decimal('2'),
+        Token.Punctuation.Comma,
+        Token.Literals.Numeric.Decimal('3'),
+        Token.Punctuation.Comma,
+        Token.Literals.Numeric.Decimal('4'),
+        Token.Punctuation.OpenBrace,
+        Token.Support.Class.System,
+        Token.Punctuation.Accessor,
+        Token.Support.Class.FunctionText('debug'),
+        Token.Punctuation.OpenParen,
+        Token.XmlDocComments.String.SingleQuoted.Begin,
+        Token.XmlDocComments.String.SingleQuoted.Text(
+          'when block 2 and 3 and 4'
+        ),
+        Token.XmlDocComments.String.SingleQuoted.End,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon,
+        Token.Punctuation.CloseBrace,
+        Token.Keywords.Switch.When,
+        Token.Literals.Numeric.Decimal('7'),
+        Token.Punctuation.OpenBrace,
+        Token.Support.Class.System,
+        Token.Punctuation.Accessor,
+        Token.Support.Class.FunctionText('debug'),
+        Token.Punctuation.OpenParen,
+        Token.XmlDocComments.String.SingleQuoted.Begin,
+        Token.XmlDocComments.String.SingleQuoted.Text('when block 7'),
+        Token.XmlDocComments.String.SingleQuoted.End,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon,
+        Token.Punctuation.CloseBrace,
+        Token.Keywords.Switch.When,
+        Token.Keywords.Switch.Else,
+        Token.Punctuation.OpenBrace,
+        Token.Comment.LeadingWhitespace('       '),
+        Token.Comment.SingleLine.Start,
+        Token.Comment.SingleLine.Text(' @TODO.'),
+        Token.Punctuation.CloseBrace,
+        Token.Punctuation.CloseBrace
+      ]);
+    });
+
+    it('simple - method example with Safe Navigator', async () => {
+      const input = Input.InMethod(`
+        switch on obj?.someInteger(i) {
+   when 2,3,4 {
+       System.debug('when block 2 and 3 and 4');
+   }
+   when 7 {
+       System.debug('when block 7');
+   }
+   when else {
+       // @TODO.
+   }
+}`);
+      const tokens = await tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Keywords.Switch.Switch,
+        Token.Keywords.Switch.On,
+        Token.Variables.Object('obj'),
+        Token.Operators.SafeNavigation,
         Token.Identifiers.MethodName('someInteger'),
         Token.Punctuation.OpenParen,
         Token.Variables.ReadWrite('i'),

--- a/test/switch.tests.ts
+++ b/test/switch.tests.ts
@@ -54,6 +54,53 @@ when else {
       ]);
     });
 
+    it('simple switch with save navigator', async () => {
+      const input = Input.InMethod(`
+switch on obj?.param {
+when 'A' {
+  System.debug('test');
+}
+when else {
+  callExternalMethod();
+}
+}`);
+      const tokens = await tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Keywords.Switch.Switch,
+        Token.Keywords.Switch.On,
+        Token.Punctuation.OpenParen,
+        Token.Variables.ReadWrite('param'),
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.OpenBrace,
+        Token.Keywords.Switch.When,
+        Token.Literals.Whitespace(' '),
+        Token.Punctuation.String.Begin,
+        Token.XmlDocComments.String.SingleQuoted.Text('A'),
+        Token.Punctuation.String.End,
+        Token.Punctuation.OpenBrace,
+        Token.Support.Class.System,
+        Token.Punctuation.Accessor,
+        Token.Support.Class.FunctionText('debug'),
+        Token.Punctuation.OpenParen,
+        Token.XmlDocComments.String.SingleQuoted.Begin,
+        Token.XmlDocComments.String.SingleQuoted.Text('test'),
+        Token.XmlDocComments.String.SingleQuoted.End,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon,
+        Token.Punctuation.CloseBrace,
+        Token.Keywords.Switch.When,
+        Token.Keywords.Switch.Else,
+        Token.Punctuation.OpenBrace,
+        Token.Identifiers.MethodName('callExternalMethod'),
+        Token.Punctuation.OpenParen,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon,
+        Token.Punctuation.CloseBrace,
+        Token.Punctuation.CloseBrace
+      ]);
+    });
+
     it('simple switch with complex string', async () => {
       const input = Input.InMethod(`
 switch on (param) {
@@ -112,6 +159,7 @@ System.debug('test');`);
       ]);
     });
 
+    // TODO - may need to test a scenario like this too
     it('multiple string switch', async () => {
       const input = Input.InMethod(`
 switch on (param) {
@@ -355,6 +403,7 @@ when else {
       ]);
     });
 
+    // TODO - may also need an example here
     it('simple - method example', async () => {
       const input = Input.InMethod(`
         switch on someInteger(i) {

--- a/test/trigger.tests.ts
+++ b/test/trigger.tests.ts
@@ -133,6 +133,34 @@ describe('Grammar', () => {
       ]);
     });
 
+    it('triggers language specific functions - complex scenario with safe navigator', async () => {
+      const input = Input.InTrigger(
+        `Trigger.newMap.get(q.opportunity__c)?.addError('Cannot delete quote');`
+      );
+      const tokens = await tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Support.Class.Trigger,
+        Token.Punctuation.Accessor,
+        Token.Support.Type.TriggerText('newMap'),
+        Token.Punctuation.Accessor,
+        Token.Support.Function.TriggerText('get'),
+        Token.Punctuation.OpenParen,
+        Token.Variables.Object('q'),
+        Token.Punctuation.Accessor,
+        Token.Variables.Property('opportunity__c'),
+        Token.Punctuation.CloseParen,
+        Token.Operators.SafeNavigation,
+        Token.Support.Function.TriggerText('addError'),
+        Token.Punctuation.OpenParen,
+        Token.Punctuation.String.Begin,
+        Token.XmlDocComments.String.SingleQuoted.Text('Cannot delete quote'),
+        Token.Punctuation.String.End,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.Semicolon
+      ]);
+    });
+
     it('SOQL in triggers', async () => {
       const input = Input.InTrigger(
         `Contact[] cons = [SELECT LastName FROM Contact WHERE AccountId IN :Trigger.new];`
@@ -217,6 +245,40 @@ describe('Grammar', () => {
         Token.Operators.Conditional.Colon,
         Token.Variables.Object('myObject'),
         Token.Punctuation.Accessor,
+        Token.Identifiers.MethodName('keys'),
+        Token.Punctuation.OpenParen,
+        Token.Punctuation.String.Begin,
+        Token.XmlDocComments.String.SingleQuoted.Text('w'),
+        Token.Punctuation.String.End,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.CloseBracket,
+        Token.Punctuation.Semicolon
+      ]);
+    });
+
+    it('SOQL in triggers using objects in clauses with safe navigator', async () => {
+      const input = Input.InTrigger(
+        `Contact[] cons = [SELECT LastName FROM Contact WHERE AccountId IN :myObject?.keys('w')];`
+      );
+      const tokens = await tokenize(input);
+
+      tokens.should.deep.equal([
+        Token.Type('Contact'),
+        Token.Punctuation.OpenBracket,
+        Token.Punctuation.CloseBracket,
+        Token.Identifiers.LocalName('cons'),
+        Token.Operators.Assignment,
+        Token.Punctuation.OpenBracket,
+        Token.Keywords.Queries.Select,
+        Token.Keywords.Queries.FieldName('LastName'),
+        Token.Keywords.Queries.From,
+        Token.Keywords.Queries.TypeName('Contact'),
+        Token.Keywords.Queries.Where,
+        Token.Keywords.Queries.FieldName('AccountId'),
+        Token.Keywords.Queries.OperatorName('IN'),
+        Token.Operators.Conditional.Colon,
+        Token.Variables.Object('myObject'),
+        Token.Operators.SafeNavigation,
         Token.Identifiers.MethodName('keys'),
         Token.Punctuation.OpenParen,
         Token.Punctuation.String.Begin,

--- a/test/utils/tokenize.ts
+++ b/test/utils/tokenize.ts
@@ -632,6 +632,10 @@ export namespace Token {
       '?',
       'keyword.operator.null-conditional.apex'
     );
+    export const SafeNavigation = createToken(
+      '?.',
+      'keyword.operator.safe-navigation.apex'
+    );
   }
 
   export namespace PrimitiveType {


### PR DESCRIPTION
### What does this PR do?
1. Updates grammar rules for [safe navigator](https://salesforce.quip.com/RlRUA1eQaHFH) around: trigger-context-declaration, soql-colon-vars, switch-statement, invocation-expression, element-access-expression, member-access-expression.
2. Test changes

### What does this PR fix or reference?
@W-7963330@

### Switch Changes
#### Functionality Before
![SyntaxHighlighting_Switch_Before](https://user-images.githubusercontent.com/45604118/93363703-d8dad880-f804-11ea-8c2e-c260e4efbdfd.gif)
#### Functionality After
![SyntaxHighlighting_Switch_after](https://user-images.githubusercontent.com/45604118/93363758-eb551200-f804-11ea-88d0-018a33d3865f.gif)

### Member Access Changes
#### Functionality Before
![SyntaxHighlighting_MemberAccess_Before](https://user-images.githubusercontent.com/45604118/93364017-45ee6e00-f805-11ea-94e6-e5c2fe15c81d.gif)
#### Functionality After
![SyntaxHighlighting_MemberAccess_After](https://user-images.githubusercontent.com/45604118/93364101-5f8fb580-f805-11ea-87fa-e9243087f183.gif)

### SOQL Bindings
#### Functionality Before
![SyntaxHighlighting_SOQL_Before](https://user-images.githubusercontent.com/45604118/93364341-aa113200-f805-11ea-870c-25aa3cce1586.gif)
#### Functionality After
![SyntaxHighlighting_SOQL_After](https://user-images.githubusercontent.com/45604118/93364160-73d3b280-f805-11ea-94c4-c51f6c547254.gif)
