### PR TITLE
Highlight FROM keyword even if no word comes after it

### DIFF
--- a/grammars/apex.tmLanguage
+++ b/grammars/apex.tmLanguage
@@ -1724,7 +1724,7 @@
       <key>from-clause</key>
       <dict>
         <key>match</key>
-        <string>(FROM)\b\s*([_\.[:alnum:]]+)\b\s*</string>
+        <string>(FROM)\b\s*([_\.[:alnum:]]+\b)?</string>
         <key>captures</key>
         <dict>
           <key>1</key>

--- a/grammars/apex.tmLanguage.cson
+++ b/grammars/apex.tmLanguage.cson
@@ -1024,7 +1024,7 @@ repository:
       }
     ]
   "from-clause":
-    match: "(FROM)\\b\\s*([_\\.[:alnum:]]+)\\b\\s*"
+    match: "(FROM)\\b\\s*([_\\.[:alnum:]]+\\b)?"
     captures:
       "1":
         name: "keyword.operator.query.from.apex"

--- a/grammars/soql.tmLanguage
+++ b/grammars/soql.tmLanguage
@@ -1706,7 +1706,7 @@
       <key>from-clause</key>
       <dict>
         <key>match</key>
-        <string>(FROM)\b\s*([_\.[:alnum:]]+)\b\s*</string>
+        <string>(FROM)\b\s*([_\.[:alnum:]]+\b)?</string>
         <key>captures</key>
         <dict>
           <key>1</key>

--- a/src/apex.tmLanguage.yml
+++ b/src/apex.tmLanguage.yml
@@ -529,7 +529,7 @@ repository:
       match: '[_.[:alpha:]][_.[:alnum:]]*'
 
   from-clause:
-    match: (FROM)\b\s*([_\.[:alnum:]]+)\b\s*
+    match: (FROM)\b\s*([_\.[:alnum:]]+\b)?
     captures:
       '1': { name: keyword.operator.query.from.apex }
       '2': { name: storage.type.apex }

--- a/test/soql/highlight_partial_from.soql
+++ b/test/soql/highlight_partial_from.soql
@@ -1,10 +1,9 @@
--- SYNTAX TEST "source.soql" "simple testcase"
+-- SYNTAX TEST "source.soql" "highlight partial FROM testcase"
 
-   SELECT Id, Name FROM Account
+   SELECT Id, Name FROM
 -- ^^^^^^ source.soql keyword.operator.query.select.apex
 --        ^^ source.soql keyword.query.field.apex
 --          ^ source.soql punctuation.separator.comma.apex
 --            ^^^^ source.soql keyword.query.field.apex
 --                 ^^^^ source.soql keyword.operator.query.from.apex
---                     ^ source.soql
---                      ^^^^^^^ source.soql storage.type.apex
+


### PR DESCRIPTION
This is useful when the users type "FROM" to get immediate feedback that they've typed a valid keyword.
